### PR TITLE
bin: fix bin/test and bin/fmt by using `find .. -exec .. {} +`

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -8,7 +8,7 @@ fi
 mkdir -p ~/.vmodules/vsl
 cp -r ./* ~/.vmodules/vsl
 
-find . -name "*.v" | xargs v fmt -w
+find . -name "*.v" -exec v fmt -w {} +
 
 rm -rf ~/.vmodules/vsl
 [ -d ~/.vmodules/old_vsl ] && mv ~/.vmodules/old_vsl ~/.vmodules/vsl

--- a/bin/test
+++ b/bin/test
@@ -11,7 +11,7 @@ mkdir -p ~/.vmodules/vsl
 cp -r ./* ~/.vmodules/vsl
 
 v test .
-find . -name '*_test' | xargs rm -f
+find . -name '*_test' -exec rm -f {} +
 
 rm -rf ~/.vmodules/vsl
 if [ -d ~/.vmodules/old_vsl ]; then


### PR DESCRIPTION
This PR fixes an issue found by shellcheck: 
```
Line 14:
find . -name '*_test' | xargs rm -f
^-- SC2038: Use -print0/-0 or -exec + to allow for non-alphanumeric filenames.
```