### PR TITLE
combinatorics: add combinations

### DIFF
--- a/combinatorics/combinatorics.v
+++ b/combinatorics/combinatorics.v
@@ -1,0 +1,90 @@
+module combinatorics
+
+import math.factorial
+
+// n_choose_k calculates the [binomial coefficient](https://mathworld.wolfram.com/BinomialCoefficient.html)
+pub fn n_choose_k(n f64, k f64) int {
+	if (k < 0.0) || (k > n) {
+		eprintln('k is outside range 0 <= k < n')
+		return 0
+	} else if k == n {
+		return 1
+	}
+	numerator := factorial.factorial(n)
+	denominator := factorial.factorial(k) * factorial.factorial(n - k)
+	return int(numerator / denominator)
+}
+
+// combinations will return an array of all length `r` combinations of `data`
+// This is as close a translation of the example algorithm listed with python's 
+// [itertools.combinations]
+// (https://docs.python.org/3.9/library/itertools.html?highlight=combinations#itertools.combinations)
+// as I could manage
+// While waiting on https://github.com/vlang/v/issues/7753 to be fixed, the function 
+// assumes int array input. Will be easy to change to generic later
+pub fn combinations(data []int, r int) [][]int {
+	// Return quickly when possible
+	n := data.len
+	if r > n {
+		return [][]int{}
+	} else if r == 1 {
+		return data.map([it])
+	}
+	// Create the empty result with correct capacity
+	n_combos := n_choose_k(n, r)
+	mut result := [][]int{cap: n_combos}
+	// Fill the first row of the result
+	result << data[0..r]
+	// Fill the rest of the rows
+	mut indices := arange(r)
+	rev_range := arange(r).reverse()
+	for {
+		mut what_is_i := -1
+		for i in rev_range {
+			if indices[i] != i + n - r {
+				what_is_i = i
+				break
+			} else if i == 0 {
+				return result
+			}
+		}
+		indices[what_is_i] = indices[what_is_i] + 1
+		for j in arange_start_stop(what_is_i + 1, r) {
+			indices[j] = indices[j - 1] + 1
+		}
+		result << get_many(data, indices)
+	}
+	return result
+}
+
+// [0, stop)
+fn arange(n int) []int {
+	mut result := []int{cap: n}
+	for idx in 0 .. n {
+		result << idx
+	}
+	return result
+}
+
+// [start, stop)
+fn arange_start_stop(start int, stop int) []int {
+	if stop <= start {
+		return []int{}
+	}
+	mut result := []int{cap: stop - start}
+	for idx in start .. stop {
+		result << idx
+	}
+	return result
+}
+
+fn get_many<T>(arr []T, inds []int) []T {
+	if inds.len == 0 {
+		return []T{}
+	}
+	mut result := []T{cap: inds.len}
+	for idx in inds {
+		result << arr[idx]
+	}
+	return result
+}

--- a/combinatorics/combinatorics_test.v
+++ b/combinatorics/combinatorics_test.v
@@ -1,0 +1,76 @@
+module combinatorics
+
+fn test_n_choose_k() {
+	assert n_choose_k(4, 2) == 6
+	assert n_choose_k(3, 3) == 1
+	assert n_choose_k(5, 2) == 10
+	assert n_choose_k(10, 6) == 210
+	assert n_choose_k(0, 3) == 0
+}
+
+fn test_arange() {
+	assert arange(3) == [0, 1, 2]
+}
+
+fn test_arange_start_stop() {
+	assert arange_start_stop(2, 5) == [2, 3, 4]
+	assert arange_start_stop(0, 3) == [0, 1, 2]
+	assert arange_start_stop(3, 2) == []int{}
+	assert arange_start_stop(1, 1) == []int{}
+}
+
+fn test_get_many() {
+	assert get_many([1, 2, 3], [0, 2]) == [1, 3]
+	assert get_many([1, 2, 3], []int{}) == []int{}
+	assert get_many([1, 2, 3], [0, 0, 0]) == [1, 1, 1]
+}
+
+// fn test_combinations_str() {
+// 	data := 'hi you'.split(' ')
+// 	expected := [['hi'], ['you']]
+// 	result := combinations(data, 1)
+// 	assert expected == result
+// }
+fn test_combinations_choose_1() {
+	data := [1, 2, 3]
+	expected := [[1], [2], [3]]
+	result := combinations(data, 1)
+	assert expected == result
+}
+
+fn test_combinations_choose_len_data() {
+	data := [1, 2, 3]
+	expected := [[1, 2, 3]]
+	result := combinations(data, data.len)
+	assert expected == result
+}
+
+fn test_combinations_simple_1() {
+	data := [1, 2, 3]
+	expected := [[1, 2], [1, 3], [2, 3]]
+	result := combinations(data, 2)
+	assert expected == result
+}
+
+fn test_combinations_simple_2() {
+	data := [4, 5, 6]
+	expected := [[4, 5], [4, 6], [5, 6]]
+	result := combinations(data, 2)
+	assert expected == result
+}
+
+fn test_combinations_simple_3() {
+	data := [1, 0, -1]
+	expected := [[1, 0], [1, -1], [0, -1]]
+	result := combinations(data, 2)
+	assert expected == result
+}
+
+fn test_combinations_longer() {
+	data := [1, 2, 3, 4, 5]
+	expected := [[1, 2], [1, 3], [1, 4],
+		[1, 5], [2, 3], [2, 4], [2, 5], [3, 4],
+		[3, 5], [4, 5]]
+	result := combinations(data, 2)
+	assert expected == result
+}


### PR DESCRIPTION
`fn combinations(data []int, r int) [][]int`
The first of a set of combinatorics functions in a combinatorics module. 

For now using `[]int` instead of `[]T` and returning eagerly as [mentioned](https://github.com/vlang/vsl/issues/31#issuecomment-753367662)

`combinations_with_replacements()` is on its way next.