### PR TITLE
Infinite iterators

### DIFF
--- a/iter/inf_iters.v
+++ b/iter/inf_iters.v
@@ -7,7 +7,7 @@ pub mut:
 	state f64
 }
 
-pub fn new_counter_iter(start f64, step f64) Counter {
+pub fn new_count_iter(start f64, step f64) Counter {
 	return Counter{
 		step: step
 		state: start
@@ -18,4 +18,39 @@ pub fn (mut c Counter) next() f64 {
 	s := c.state
 	c.state += c.step
 	return s
+}
+
+pub struct Cycler {
+mut:
+	idx int
+pub:
+	data []f64
+}
+
+pub fn new_cycle_iter(data []f64) Cycler {
+	return Cycler{
+		data: data
+		idx: 0
+	}
+}
+
+pub fn (mut c Cycler) next() f64 {
+	this_idx := c.idx % c.data.len
+	c.idx++
+	return c.data[this_idx]
+}
+
+pub struct Repeater {
+pub:
+	item f64
+}
+
+pub fn new_repeat_iter(item f64) Repeater {
+	return Repeater{
+		item: item
+	}
+}
+
+pub fn (m Repeater) next() f64 {
+	return m.item
 }

--- a/iter/inf_iters.v
+++ b/iter/inf_iters.v
@@ -1,0 +1,21 @@
+module iter
+
+pub struct Counter {
+pub:
+	step f64
+pub mut:
+	state f64
+}
+
+pub fn new_counter_iter(start f64, step f64) Counter {
+	return Counter{
+		step: step
+		state: start
+	}
+}
+
+pub fn (mut c Counter) next() f64 {
+	s := c.state
+	c.state += c.step
+	return s
+}

--- a/iter/inf_iters_test.v
+++ b/iter/inf_iters_test.v
@@ -1,7 +1,7 @@
 module iter
 
 fn test_counter_1() {
-	mut counter := new_counter_iter(10, 1)
+	mut counter := new_count_iter(10, 1)
 	assert counter.next() == 10
 	assert counter.next() == 11
 	assert counter.next() == 12
@@ -10,7 +10,7 @@ fn test_counter_1() {
 }
 
 fn test_counter_2() {
-	mut counter := new_counter_iter(0, 3)
+	mut counter := new_count_iter(0, 3)
 	assert counter.next() == 0
 	assert counter.next() == 3
 	assert counter.next() == 6
@@ -19,7 +19,7 @@ fn test_counter_2() {
 }
 
 fn test_counter_3() {
-	mut counter := new_counter_iter(3, -1)
+	mut counter := new_count_iter(3, -1)
 	assert counter.next() == 3
 	assert counter.next() == 2
 	assert counter.next() == 1
@@ -29,11 +29,37 @@ fn test_counter_3() {
 }
 
 fn test_counter_4() {
-	mut counter := new_counter_iter(4, -3)
+	mut counter := new_count_iter(4, -3)
 	assert counter.next() == 4
 	assert counter.next() == 1
 	assert counter.next() == -2
 	assert counter.next() == -5
 	assert counter.next() == -8
 	assert counter.next() == -11
+}
+
+fn test_cycle_1() {
+	mut cycler := new_cycle_iter([1., 2., 3.])
+	assert cycler.next() == 1
+	assert cycler.next() == 2
+	assert cycler.next() == 3
+	assert cycler.next() == 1
+	assert cycler.next() == 2
+}
+
+fn test_cycle_2() {
+	mut cycler := new_cycle_iter([10., 0., 42., 12.])
+	assert cycler.next() == 10
+	assert cycler.next() == 0
+	assert cycler.next() == 42
+	assert cycler.next() == 12
+	assert cycler.next() == 10
+	assert cycler.next() == 0
+}
+
+fn test_repeat() {
+	r := new_repeat_iter(3)
+	assert r.next() == 3
+	assert r.next() == 3
+	assert r.next() == 3
 }

--- a/iter/inf_iters_test.v
+++ b/iter/inf_iters_test.v
@@ -1,0 +1,39 @@
+module iter
+
+fn test_counter_1() {
+	mut counter := new_counter_iter(10, 1)
+	assert counter.next() == 10
+	assert counter.next() == 11
+	assert counter.next() == 12
+	assert counter.next() == 13
+	assert counter.next() == 14
+}
+
+fn test_counter_2() {
+	mut counter := new_counter_iter(0, 3)
+	assert counter.next() == 0
+	assert counter.next() == 3
+	assert counter.next() == 6
+	assert counter.next() == 9
+	assert counter.next() == 12
+}
+
+fn test_counter_3() {
+	mut counter := new_counter_iter(3, -1)
+	assert counter.next() == 3
+	assert counter.next() == 2
+	assert counter.next() == 1
+	assert counter.next() == 0
+	assert counter.next() == -1
+	assert counter.next() == -2
+}
+
+fn test_counter_4() {
+	mut counter := new_counter_iter(4, -3)
+	assert counter.next() == 4
+	assert counter.next() == 1
+	assert counter.next() == -2
+	assert counter.next() == -5
+	assert counter.next() == -8
+	assert counter.next() == -11
+}


### PR DESCRIPTION
Made three iterators to mimic python [itertools](https://docs.python.org/3.9/library/itertools.html) three infinite iterators

- `count()`
- `cycle()`
- `repeat()`

As of writing this, generics were still causing crashes; using `f64` instead.