### PR TITLE
Add weight support for KNN (backwards compatible)

### DIFF
--- a/ml/knn.v
+++ b/ml/knn.v
@@ -49,6 +49,25 @@ pub fn new_knn(mut data Data) &KNN {
 	return &knn
 }
 
+// set_weights will set the weights for the KNN. They default to
+// 1.0 for every class when this function is not called.
+pub fn (mut knn KNN) set_weights(weights map[f64]f64) {
+	mut new_weights := map[f64]f64{}
+	for k, v in weights {
+		if k !in knn.data.y {
+			errors.vsl_panic('KNN.set_weights expects weights (map[f64]f64) to have ' +
+				'all its keys present in the KNN\'s classes.', .einval)
+		}
+		new_weights[k] = v
+	}
+	for class in knn.data.y {
+		if class !in new_weights {
+			new_weights[class] = 1.0
+		}
+	}
+	knn.weights = new_weights.clone()
+}
+
 // update perform updates after data has been changed (as an Observer)
 pub fn (mut knn KNN) update() {
 	mut x := knn.data.x.get_deep2()

--- a/ml/knn.v
+++ b/ml/knn.v
@@ -15,7 +15,7 @@ pub mut:
 // Neighbor is a support struct to help organizing the code
 // and calculating distances, as well as sorting using array.sort.
 struct Neighbor {
-mut:
+	mut:
 	point    []f64
 	class    f64
 	distance f64
@@ -36,14 +36,7 @@ pub fn new_knn(mut data Data) &KNN {
 		errors.vsl_panic('vls.ml.knn.new_knn expects data.y to have at least one element.',
 			.einval)
 	}
-	mut weights := map[f64]f64{}
-	for class in data.y {
-		weights[class] = 1.0
-	}
-	mut knn := KNN{
-		data: data
-		weights: weights
-	}
+	mut knn := KNN{data: data}
 	data.add_observer(knn) // need to recompute neighbors upon data changes
 	knn.update() // compute first neighbors
 	return &knn
@@ -82,6 +75,11 @@ pub fn (mut knn KNN) update() {
 			class: knn.data.y[i]
 		}
 	}
+        mut weights := map[f64]f64{}
+	for class in knn.data.y {
+		weights[class] = 1.0
+	}
+        knn.weights = weights.clone()
 }
 
 // data needed for KNN.predict

--- a/ml/knn.v
+++ b/ml/knn.v
@@ -58,6 +58,10 @@ pub fn (mut knn KNN) set_weights(weights map[f64]f64) {
 			errors.vsl_panic('KNN.set_weights expects weights (map[f64]f64) to have ' +
 				'all its keys present in the KNN\'s classes.', .einval)
 		}
+		if v == 0.0 {
+			errors.vsl_panic('KNN.set_weights expects weights (map[f64]f64) to not have ' +
+				'zeroes, as it cannot divide by zero.', .ezerodiv)
+		}
 		new_weights[k] = v
 	}
 	for class in knn.data.y {

--- a/ml/knn_test.v
+++ b/ml/knn_test.v
@@ -56,3 +56,37 @@ fn test_knn_predict_with_data_change() {
 	assert knn.predict(k: 1, to_pred: [0.333333, 0.66666]) == 0.0
 	assert knn.predict(k: 1, to_pred: [11., 9.3]) == 1.0
 }
+
+fn test_knn_predict_with_weights() {
+	x := [
+		[0.],
+		[0.5],
+		[9.7],
+		[10.2],
+		[-100.4],
+		[-174.58883034],
+		[9.85]
+	]
+	y := [
+		1.,
+		1,
+		2,
+		2,
+		3,
+		3,
+		3
+	]
+	mut w := map{
+		1.: 1.
+		2: 1
+		3: 1
+	}
+	mut train_data := data_from_raw_xy_sep(x, y)
+	mut knn := new_knn(mut train_data)
+	knn.set_weights(w)
+	assert knn.predict(k: 5, to_pred: [9.8]) == 2.
+
+	w[3.] = 2.
+	knn.set_weights(w)
+	assert knn.predict(k: 5, to_pred: [9.8]) == 3.
+}


### PR DESCRIPTION
Users can now specify the weight for each class by using a `map[f64]f64`. This is totally optional, defaulting to weight 1.0 for each class. The way it works is exactly the same as the previous non-weighted KNN, except that it divides distance by weight in order to find the most suitable neighbors. I am unsure if this is the best approach but it makes sense in my head. Let me know if there is something wrong with this concept.

I also added a zerodiv check (used the proper vsl.error this time instead of a V panic 😛), but if I set any weight to zero there is a runtime error going on. I can't see what's wrong with my if statement, if I print the variable `v` (line 61 of ml/knn.v) it shows 0 just fine but gives me an invalid memory access error.

Digging deep into this, I can only assume it is a problem in `errors/strerrno.v`, because if I remove `estr` from line 11 in `errors/errors.v` (`vsl_panic()`) the error goes away, as seen [here](https://imgur.com/a/4y4uzC6). I haven't been able to solve such problem and have opened an issue.