### PR TITLE
Fixed major inplace sorting bug in KNN.predict

### DIFF
--- a/ml/knn.v
+++ b/ml/knn.v
@@ -96,6 +96,7 @@ pub fn (mut knn KNN) update() {
 pub struct PredictConfig {
 	max_iter int
 	k        int
+mut:
 	to_pred  []f64
 }
 
@@ -121,7 +122,8 @@ pub fn (mut knn KNN) predict(config PredictConfig) f64 {
 	for i := 0; i < x.len; i++ {
 		knn.neighbors[i].distance = l2_distance_unitary(to_pred, x[i]) / knn.weights[knn.neighbors[i].class]
 	}
-	knn.neighbors.sort(a.distance < b.distance)
+	mut neighbors := knn.neighbors.clone()
+	neighbors.sort(a.distance < b.distance)
 
 	// Break ties
 	mut new_k := k
@@ -136,7 +138,7 @@ pub fn (mut knn KNN) predict(config PredictConfig) f64 {
 		}
 
 		tied = false
-		mut tmp_neighbors := knn.neighbors[0..new_k].clone()
+		mut tmp_neighbors := neighbors[0..new_k].clone()
 		mut freq := map[f64]int{}
 		for n in tmp_neighbors {
 			if n.class !in freq {

--- a/ml/knn_test.v
+++ b/ml/knn_test.v
@@ -86,7 +86,7 @@ fn test_knn_predict_with_weights() {
 	knn.set_weights(w)
 	assert knn.predict(k: 5, to_pred: [9.8]) == 2.
 
-	w[3.] = 2.
+	w[3.] = 100.
 	knn.set_weights(w)
 	assert knn.predict(k: 5, to_pred: [9.8]) == 3.
 }


### PR DESCRIPTION
For some reason, sorting knn.neighbors changes some things that should not be changed. In a test I did I got this:
```
[48, 671] to [215, 619]: 174.9085475327035
[48, 671] to [850, 154]: 954.1975686407925
[48, 671] to [48, 671]: 0
Looking at: [48, 671]
Closest neighbor:
vsl.ml.Neighbor{
    point: [850, 154]
    class: 1
    distance: 0
}
Returning 1
```
All I did was clone knn.neighbors to a mut array and use this array instead. Weird thing, man... weird thing.