### PR TITLE
Add NLP tools and fast inverse square root

### DIFF
--- a/blas/vlas/level1f64.v
+++ b/blas/vlas/level1f64.v
@@ -142,7 +142,7 @@ pub fn dswap(n int, mut x []f64, incx int, mut y []f64, incy int) {
 	if incy < 0 {
 		iy = (-n + 1) * incy
 	}
-	for i in 0 .. n {
+	for _ in 0 .. n {
 		tmp := x[ix]
 		x[ix] = y[iy]
 		y[iy] = tmp

--- a/blas/vlas/level1f64.v
+++ b/blas/vlas/level1f64.v
@@ -186,7 +186,7 @@ pub fn dcopy(n int, x []f64, incx int, mut y []f64, incy int) {
 	if incy < 0 {
 		iy = (-n + 1) * incy
 	}
-	for i in 0 .. n {
+	for _ in 0 .. n {
 		y[iy] = x[ix]
 		ix += incx
 		iy += incy

--- a/ml/count_vectorizer.v
+++ b/ml/count_vectorizer.v
@@ -1,0 +1,70 @@
+module ml
+
+import vsl.errors
+
+const ngram_sep = 'NGRAMSEP'
+
+// most_frequent_ngrams returns an array with up to `n_features` elements
+// denoting the most frequent ngrams in `ngrams`.
+// Since V does not support map of arrays, the ngrams are joined by
+// "NGRAMSEP". If `n_features` is <= 0, it will be set to ngrams.len.
+pub fn most_frequent_ngrams(ngrams [][]string, n_features int) [][]string {
+	if ngrams.len == 0 {
+		errors.vsl_panic(
+			'ngram_frequency_map expects a non-empty array of ngrams.',
+			.einval
+		)
+	}
+	mut n_features_ := n_features
+	if n_features <= 0 {
+		n_features_ = ngrams.len
+	}
+	else if n_features > ngrams.len {
+		errors.vsl_panic(
+			'n_features cannot be greater than the amount of ngrams.',
+			.einval
+		)
+	}
+	mut freq_map := map[string]int
+	mut joined := ngrams.map(it.join(ngram_sep))
+	// ngrams are joined by `ngram_sep` due to maps
+	// not supporting []string keys yet.
+	for ngram in joined {
+		if ngram !in freq_map {
+			freq_map[ngram] = 0
+		}
+		freq_map[ngram]++
+	}
+	mut result := [][]string{}
+	for _ in 0..n_features_ {
+		keys := freq_map.keys()
+		if keys.len == 0 { break }
+		mut most_frequent := keys[0]
+		for ngram in keys {
+			if freq_map[ngram] > freq_map[most_frequent] {
+				most_frequent = ngram
+			}
+		}
+		result << most_frequent.split(ngram_sep)
+		freq_map.delete(most_frequent)
+	}
+	return result
+}
+
+// count_vectorize will give you an array of occurrences of each
+// ngram from `ngrams` in `most_frequent`.
+// Example: assume `ng := [['hello'], ['hello'], ['hi']]`.
+// `ml.count_vectorize(ng, ml.most_frequent_ngrams(ng, 0))`
+// should return `[2, 1]`. See `most_frequent_ngrams for more`
+// details on how it works.
+pub fn count_vectorize(ngrams [][]string, most_frequent [][]string) []int {
+	mut result := []int{len: most_frequent.len, init: 0}
+	for ngram in ngrams {
+		for i, m_f in most_frequent {
+			if ngram == m_f {
+				result[i]++
+			}
+		}
+	}
+	return result
+}

--- a/ml/count_vectorizer.v
+++ b/ml/count_vectorizer.v
@@ -2,8 +2,6 @@ module ml
 
 import vsl.errors
 
-const ngram_sep = 'NGRAMSEP'
-
 // most_frequent_ngrams returns an array with up to `n_features` elements
 // denoting the most frequent ngrams in `ngrams`.
 // Since V does not support map of arrays, the ngrams are joined by

--- a/ml/lancaster_stemmer.v
+++ b/ml/lancaster_stemmer.v
@@ -1,0 +1,226 @@
+module ml
+
+import regex
+import vsl.errors
+
+/*
+The pieces of code for LancasterStemmer and its utilities found below
+were originally written in Python by the NLTK Project (Copyright 2001 - 2021),
+more specifically by Steven Tomcavage. This is just a translation from Python to V
+with minor changes, such as naming convention and code structure.
+
+The nltk library, developed by the NLTK Project (https://www.nltk.org),
+is licensed under Apache 2.0, available at <https://www.apache.org/licenses/LICENSE-2.0>.
+
+The original code for the LancasterStemmer, which was acquired from NLTK's `stem`
+submodule can be found at <https://www.nltk.org/_modules/nltk/stem/lancaster.html>.
+
+All credits go to the respective authors of NLTK's LancasterStemmer implementation.
+*/
+
+pub struct LancasterStemmer {
+mut:
+	rule_map		map[string][]string
+pub mut:
+	rules			[]string = [
+        'ai*2.', 'a*1.', 'bb1.', 'city3s.', 'ci2>',
+        'cn1t>', 'dd1.', 'dei3y>', 'deec2ss.', 'dee1.',
+        'de2>', 'dooh4>', 'e1>', 'feil1v.', 'fi2>',
+		'gni3>', 'gai3y.', 'ga2>', 'gg1.', 'ht*2.',
+        'hsiug5ct.', 'hsi3>', 'i*1.', 'i1y>', 'ji1d.',
+		'juf1s.', 'ju1d.', 'jo1d.', 'jeh1r.', 'jrev1t.',
+		'jsim2t.', 'jn1d.', 'j1s.', 'lbaifi6.', 'lbai4y.',
+        'lba3>', 'lbi3.', 'lib2l>', 'lc1.', 'lufi4y.',
+		'luf3>', 'lu2.', 'lai3>', 'lau3>', 'la2>', 'll1.',
+        'mui3.', 'mu*2.', 'msi3>', 'mm1.', 'nois4j>',
+        'noix4ct.', 'noi3>', 'nai3>', 'na2>', 'nee0.',
+        'ne2>', 'nn1.', 'pihs4>', 'pp1.', 're2>', 'rae0.',
+        'ra2.', 'ro2>', 'ru2>', 'rr1.', 'rt1>', 'rei3y>',
+		'sei3y>', 'sis2.', 'si2>', 'ssen4>', 'ss0.',
+        'suo3>', 'su*2.', 's*1>', 's0.', 'tacilp4y.', 'ta2>',
+        'tnem4>', 'tne3>', 'tna3>', 'tpir2b.', 'tpro2b.',
+		'tcud1.', 'tpmus2.', 'tpec2iv.', 'tulo2v.', 'tsis0.',
+		'tsi3>', 'tt1.', 'uqi3.', 'ugo1.', 'vis3j>', 'vie0.',
+		'vi2>', 'ylb1>', 'yli3y>', 'ylp0.', 'yl2>', 'ygo1.',
+		'yhp1.', 'ymo1.', 'ypo1.', 'yti3>', 'yte3>', 'ytl2.',
+		'yrtsi5.', 'yra3>', 'yro3>', 'yfi3.', 'ycn2t>',
+		'yca3>', 'zi2>', 'zy1s.'
+	]
+	strip_prefix	bool
+}
+
+// new_lancaster_stemmer returns a LancasterStemmer struct with a
+// predefined set of stemming rules.
+pub fn new_lancaster_stemmer(strip_prefix bool) LancasterStemmer {
+	return LancasterStemmer{strip_prefix: strip_prefix}
+}
+
+// parse_rules makes sure all rules provided are allowed by the following
+// regex: `^[a-z]+\*?\d[a-z]*[>\.]?$`.
+fn (mut stemmer LancasterStemmer) parse_rules(rules []string) {
+	mut valid_rule := regex.regex_opt('^[a-z]+\\*?\\d[a-z]*[>\\.]?$') or {
+		errors.vsl_panic(
+			'Regex error in LancasterStemmer, this should never happen.',
+			.efailed
+		)
+		return
+	}
+	for rule in rules {
+		regex_match, _ := valid_rule.match_string(rule)
+		if regex_match == -1 {
+			errors.vsl_panic('Invalid LancasterStemmer rule "$rule"', .einval)
+		}
+		// Indexing a string returns a byte. Turn it into an array of bytes
+		// and call bytestr() to turn it into a string.
+		first_letter := [rule[0]].bytestr()
+		if first_letter in stemmer.rule_map {
+			stemmer.rule_map[first_letter] << rule
+		}
+		else {
+			stemmer.rule_map[first_letter] = [rule]
+		}
+	}
+}
+
+// set_rules redefines the rules of stemmer and parses it.
+pub fn (mut stemmer LancasterStemmer) set_rules(rules []string) {
+	if rules.len == 0 {
+		errors.vsl_panic('No LancasterStemmer rules provided.', .einval)
+	}
+	stemmer.rule_map = map[string][]string
+	stemmer.rules = rules
+	// I know this is ugly and could simply be stemmer.parse_rules()
+	// but I decided to keep it like this just in case the user wants
+	// to parse some set of rules and not assign it to their stemmer
+	// just yet.
+	stemmer.parse_rules(rules)
+}
+
+// stem serves as a wrapper for do_stemming, which is private.
+pub fn (mut stemmer LancasterStemmer) stem(word string) string {
+	mut lowercase := word.to_lower()
+	strip := fn (w string) string {
+		for prefix in ['kilo', 'micro', 'milli', 'intra', 'ultra', 'mega', 'nano', 'pico', 'pseudo'] {
+			if w.starts_with(prefix) {
+				return w.substr(prefix.len, w.len)
+			}
+		}
+		return w
+	}
+	if stemmer.strip_prefix {
+		lowercase = strip(lowercase)
+	}
+	mut intact_word := lowercase
+	if stemmer.rule_map.len == 0 {
+		stemmer.parse_rules(stemmer.rules)
+	}
+	return stemmer.do_stemming(lowercase, intact_word)
+}
+
+// do_stemming performs the actual stemming based on the set of rules
+// and the regex `^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$`.
+fn (stemmer LancasterStemmer) do_stemming(word_ string, intact_word string) string {
+	mut word := word_
+	mut valid_rule := regex.regex_opt('^([a-z]+)(\\*?)(\\d)([a-z]*)([>\\.]?)$') or {
+		errors.vsl_panic(
+			'Regex error in LancasterStemmer, this should never happen.',
+			.efailed
+		)
+		return word_
+	}
+	mut proceed := true
+	for proceed {
+		mut last_letter_position := -1
+		for char_idx, character in word {
+			if 'abcdefghijklmnopqrstuvwxyz'.contains([character].bytestr()) {
+				last_letter_position = char_idx
+			}
+			else {
+				break
+			}
+		}
+		if last_letter_position == -1 || [word[last_letter_position]].bytestr() !in stemmer.rule_map {
+			proceed = false
+		}
+		else {
+			mut rule_was_applied := false
+			for rule in stemmer.rule_map[[word[last_letter_position]].bytestr()] {
+				regex_match, _ := valid_rule.match_string(rule)
+				if regex_match >= 0 {
+					gs := valid_rule.get_group_list()
+
+					mut ending_string := ''
+					if gs[0].start != -1 && gs[0].end != -1 {
+						ending_string = rule.substr(gs[0].start, gs[0].end)
+					}
+					mut intact_flag := ''
+					if gs[1].start != -1 && gs[1].end != -1 {
+						intact_flag = rule.substr(gs[1].start, gs[1].end)
+					}
+					mut remove_total := 0
+					if gs[2].start != -1 && gs[2].end != -1 {
+						remove_total = rule.substr(gs[2].start, gs[2].end).int()
+					}
+					mut append_string := ''
+					if gs[3].start != -1 && gs[3].end != -1 {
+						append_string = rule.substr(gs[3].start, gs[3].end)
+					}
+					mut cont_flag := ''
+					if gs[4].start != -1 && gs[4].end != -1 {
+						cont_flag = rule.substr(gs[4].start, gs[4].end)
+					}
+
+					is_acceptable := fn (w string, r int) bool {
+						if 'aeiouy'.contains([w[0]].bytestr()) {
+							if w.len - r >= 2 {
+								return true
+							}
+						}
+						else if w.len - r >= 3 {
+							if 'aeiouy'.contains([w[1]].bytestr()) ||
+							   'aeiouy'.contains([w[2]].bytestr()) {
+								return true
+							}
+						}
+						return false
+					}
+
+					apply_rule := fn (w_ string, r int, a string) string {
+						mut w := w_
+						new_word_length := w.len - r
+						w = w.substr(0, new_word_length)
+						if a.len > 0 {
+							w += a
+						}
+						return w
+					}
+
+					if word.ends_with(ending_string.reverse()) {
+						if intact_flag.len > 0 {
+							if word == intact_word && is_acceptable(word, remove_total) {
+								word = apply_rule(word, remove_total, append_string)
+								rule_was_applied = true
+								if cont_flag == '.' {
+									proceed = true
+								}
+								break
+							}
+						}
+						else if is_acceptable(word, remove_total) {
+							word = apply_rule(word, remove_total, append_string)
+							rule_was_applied = true
+							if cont_flag == '.' {
+								proceed = false
+							}
+							break
+						}
+					}
+				}
+			}
+			if !rule_was_applied {
+				proceed = false
+			}
+		}
+	}
+	return word
+}

--- a/ml/lancaster_stemmer.v
+++ b/ml/lancaster_stemmer.v
@@ -23,22 +23,22 @@ mut:
 	rule_map		map[string][]string
 pub mut:
 	rules			[]string = [
-        'ai*2.', 'a*1.', 'bb1.', 'city3s.', 'ci2>',
-        'cn1t>', 'dd1.', 'dei3y>', 'deec2ss.', 'dee1.',
-        'de2>', 'dooh4>', 'e1>', 'feil1v.', 'fi2>',
+		'ai*2.', 'a*1.', 'bb1.', 'city3s.', 'ci2>',
+		'cn1t>', 'dd1.', 'dei3y>', 'deec2ss.', 'dee1.',
+		'de2>', 'dooh4>', 'e1>', 'feil1v.', 'fi2>',
 		'gni3>', 'gai3y.', 'ga2>', 'gg1.', 'ht*2.',
-        'hsiug5ct.', 'hsi3>', 'i*1.', 'i1y>', 'ji1d.',
+		'hsiug5ct.', 'hsi3>', 'i*1.', 'i1y>', 'ji1d.',
 		'juf1s.', 'ju1d.', 'jo1d.', 'jeh1r.', 'jrev1t.',
 		'jsim2t.', 'jn1d.', 'j1s.', 'lbaifi6.', 'lbai4y.',
-        'lba3>', 'lbi3.', 'lib2l>', 'lc1.', 'lufi4y.',
+		'lba3>', 'lbi3.', 'lib2l>', 'lc1.', 'lufi4y.',
 		'luf3>', 'lu2.', 'lai3>', 'lau3>', 'la2>', 'll1.',
-        'mui3.', 'mu*2.', 'msi3>', 'mm1.', 'nois4j>',
-        'noix4ct.', 'noi3>', 'nai3>', 'na2>', 'nee0.',
-        'ne2>', 'nn1.', 'pihs4>', 'pp1.', 're2>', 'rae0.',
-        'ra2.', 'ro2>', 'ru2>', 'rr1.', 'rt1>', 'rei3y>',
+		'mui3.', 'mu*2.', 'msi3>', 'mm1.', 'nois4j>',
+		'noix4ct.', 'noi3>', 'nai3>', 'na2>', 'nee0.',
+		'ne2>', 'nn1.', 'pihs4>', 'pp1.', 're2>', 'rae0.',
+		'ra2.', 'ro2>', 'ru2>', 'rr1.', 'rt1>', 'rei3y>',
 		'sei3y>', 'sis2.', 'si2>', 'ssen4>', 'ss0.',
-        'suo3>', 'su*2.', 's*1>', 's0.', 'tacilp4y.', 'ta2>',
-        'tnem4>', 'tne3>', 'tna3>', 'tpir2b.', 'tpro2b.',
+		'suo3>', 'su*2.', 's*1>', 's0.', 'tacilp4y.', 'ta2>',
+		'tnem4>', 'tne3>', 'tna3>', 'tpir2b.', 'tpro2b.',
 		'tcud1.', 'tpmus2.', 'tpec2iv.', 'tulo2v.', 'tsis0.',
 		'tsi3>', 'tt1.', 'uqi3.', 'ugo1.', 'vis3j>', 'vie0.',
 		'vi2>', 'ylb1>', 'yli3y>', 'ylp0.', 'yl2>', 'ygo1.',
@@ -147,28 +147,11 @@ fn (stemmer LancasterStemmer) do_stemming(word_ string, intact_word string) stri
 			for rule in stemmer.rule_map[[word[last_letter_position]].bytestr()] {
 				regex_match, _ := valid_rule.match_string(rule)
 				if regex_match >= 0 {
-					gs := valid_rule.get_group_list()
-
-					mut ending_string := ''
-					if gs[0].start != -1 && gs[0].end != -1 {
-						ending_string = rule.substr(gs[0].start, gs[0].end)
-					}
-					mut intact_flag := ''
-					if gs[1].start != -1 && gs[1].end != -1 {
-						intact_flag = rule.substr(gs[1].start, gs[1].end)
-					}
-					mut remove_total := 0
-					if gs[2].start != -1 && gs[2].end != -1 {
-						remove_total = rule.substr(gs[2].start, gs[2].end).int()
-					}
-					mut append_string := ''
-					if gs[3].start != -1 && gs[3].end != -1 {
-						append_string = rule.substr(gs[3].start, gs[3].end)
-					}
-					mut cont_flag := ''
-					if gs[4].start != -1 && gs[4].end != -1 {
-						cont_flag = rule.substr(gs[4].start, gs[4].end)
-					}
+					ending_string	:= valid_rule.get_group_by_id(rule, 0)
+					intact_flag		:= valid_rule.get_group_by_id(rule, 1)
+					remove_total	:= valid_rule.get_group_by_id(rule, 2).int()
+					append_string	:= valid_rule.get_group_by_id(rule, 3)
+					cont_flag		:= valid_rule.get_group_by_id(rule, 4)
 
 					is_acceptable := fn (w string, r int) bool {
 						if 'aeiouy'.contains([w[0]].bytestr()) {

--- a/ml/tf_idf.v
+++ b/ml/tf_idf.v
@@ -1,0 +1,91 @@
+module ml
+
+import math
+
+import vsl.errors
+
+// TODO: Optimize the code below, if possible.
+
+// term_frequencies will return the frequency of each term in a sentence.
+// However, since in VSL NLP tools we deal with ngrams instead of regular
+// "words" (1gram tokens), our sentence is actually a collection of ngrams
+// and our words/terms are the ngrams themselves. Keep in mind that, since
+// V does NOT support maps of arrays, ngrams are joined by the constant
+// `ngram_sep`, which can be found in `ml/tokenizer.v`. This is why it
+// returns a `map[string]f64` and not a `map[[]string]f64`.
+pub fn term_frequencies(ngrams_sentence [][]string) map[string]f64 {
+	if ngrams_sentence.len == 0 {
+		errors.vsl_panic(
+			'ml.term_frequencies expects ngrams_sentence to have at least 1 ngram.',
+			.einval
+		)
+	}
+	mut tf := map[string]f64
+	joined := ngrams_sentence.map(it.join(ml.ngram_sep))
+	mut used_ngrams := []string{}
+	for ngram in joined {
+		if ngram in used_ngrams { continue }
+		mut ngram_frequency := 0.0
+		for ngram2 in joined {
+			if ngram == ngram2 {
+				ngram_frequency += 1.0
+			}
+		}
+		tf[ngram] = ngram_frequency / f64(ngrams_sentence.len)
+		used_ngrams << ngram
+	}
+	return tf
+}
+
+// inverse_document_frequencies will return the IDF of each term.  However,
+// since in VSL NLP tools we deal with ngrams instead of regular "words"
+// (1gram tokens), our document is actually a collection of ngrams and our
+// words/terms are the ngrams themselves. This means that a document (a
+// collection of sentences) is actually a `[][][]string` (array of sentences,
+// which by themselves are arrays of ngrams, which are arrays of string).
+// Keep in mind that, since V does NOT support maps of arrays, ngrams are
+// joined by the constant `ngram_sep`, which can be found in `ml/tokenizer.v`.
+// This is why it returns a `map[string]f64` and not a `map[[]string]f64`.
+pub fn inverse_document_frequencies(document [][][]string) map[string]f64 {
+	if document.len == 0 {
+		errors.vsl_panic(
+			'ml.inverse_document_frequencies expects at least one sentence.',
+			.einval
+		)
+	}
+
+	mut idf := map[string]f64
+
+	mut unique_ngrams := []string{}
+	for sentence in document {
+		for ngram in sentence.map(it.join(ml.ngram_sep)) {
+			if ngram !in unique_ngrams {
+				unique_ngrams << ngram
+			}
+		}
+	}
+
+	for ngram in unique_ngrams {
+		mut n_sentences_with_ngram := 0
+		for sentence in document {
+			if ngram in sentence.map(it.join(ml.ngram_sep)) {
+				n_sentences_with_ngram++
+			}
+		}
+		// log base doesnt really matter, as long as it is indeed a logarithm.
+		// I chose 2 because it seems to be the most common log base for computer
+		// science in general.
+		idf[ngram] = math.log2(
+			f64(document.len) / f64(n_sentences_with_ngram)
+		)
+	}
+	return idf
+}
+
+// tf_idf will return the TF * IDF for any given ngram, in a sentence, in a
+// document.
+pub fn tf_idf(ngram []string, sentence [][]string, document [][][]string) f64 {
+	tf := term_frequencies(sentence)[ngram.join(ml.ngram_sep)]
+	idf := inverse_document_frequencies(document)[ngram.join(ml.ngram_sep)]
+	return tf * idf
+}

--- a/ml/tf_idf.v
+++ b/ml/tf_idf.v
@@ -22,30 +22,22 @@ pub fn term_frequencies(ngrams_sentence [][]string) map[string]f64 {
 	}
 	mut tf := map[string]f64
 	joined := ngrams_sentence.map(it.join(ml.ngram_sep))
-	mut used_ngrams := []string{}
+	mut freq_map := map[string]int
 	for ngram in joined {
-		if ngram in used_ngrams { continue }
-		mut ngram_frequency := 0.0
-		for ngram2 in joined {
-			if ngram == ngram2 {
-				ngram_frequency += 1.0
-			}
+		if ngram !in freq_map {
+			freq_map[ngram] = 0
 		}
-		tf[ngram] = ngram_frequency / f64(ngrams_sentence.len)
-		used_ngrams << ngram
+		freq_map[ngram]++
+	}
+	for ngram in joined {
+		tf[ngram] = freq_map[ngram] / f64(ngrams_sentence.len)
 	}
 	return tf
 }
 
-// inverse_document_frequencies will return the IDF of each term.  However,
-// since in VSL NLP tools we deal with ngrams instead of regular "words"
-// (1gram tokens), our document is actually a collection of ngrams and our
-// words/terms are the ngrams themselves. This means that a document (a
-// collection of sentences) is actually a `[][][]string` (array of sentences,
-// which by themselves are arrays of ngrams, which are arrays of string).
-// Keep in mind that, since V does NOT support maps of arrays, ngrams are
-// joined by the constant `ngram_sep`, which can be found in `ml/tokenizer.v`.
-// This is why it returns a `map[string]f64` and not a `map[[]string]f64`.
+// inverse_document_frequencies will return the IDF of each term by calling
+// `term_idf` on each unique ngram. Check `term_idf` for more details about
+// the parameter `document`.
 pub fn inverse_document_frequencies(document [][][]string) map[string]f64 {
 	if document.len == 0 {
 		errors.vsl_panic(
@@ -66,26 +58,53 @@ pub fn inverse_document_frequencies(document [][][]string) map[string]f64 {
 	}
 
 	for ngram in unique_ngrams {
-		mut n_sentences_with_ngram := 0
-		for sentence in document {
-			if ngram in sentence.map(it.join(ml.ngram_sep)) {
-				n_sentences_with_ngram++
-			}
-		}
-		// log base doesnt really matter, as long as it is indeed a logarithm.
-		// I chose 2 because it seems to be the most common log base for computer
-		// science in general.
-		idf[ngram] = math.log2(
-			f64(document.len) / f64(n_sentences_with_ngram)
-		)
+		idf[ngram] = term_idf(ngram.split(ml.ngram_sep), document)
 	}
 	return idf
+}
+
+// term_idf will return the IDF of a single term term.  However, since in
+// VSL NLP tools we deal with ngrams instead of regular "words" (1gram
+// tokens), our document is actually a collection of ngrams and our
+// words/terms are the ngrams themselves. This means that a document (a
+// collection of sentences) is actually a `[][][]string` (array of sentences,
+// which by themselves are arrays of ngrams, which are arrays of string).
+// Keep in mind that, since V does NOT support maps of arrays, ngrams are
+// joined by the constant `ngram_sep`, which can be found in `ml/tokenizer.v`.
+// This is why it returns a `map[string]f64` and not a `map[[]string]f64`.
+pub fn term_idf(term []string, document [][][]string) f64 {
+	if document.len == 0 {
+		errors.vsl_panic(
+			'ml.term_idf expects at least one sentence.',
+			.einval
+		)
+	}
+	if term.len == 0 {
+		errors.vsl_panic(
+			'ml.term_idf expects at least one ngram.',
+			.einval
+		)
+	}
+
+	ngram := term.join(ml.ngram_sep)
+
+	mut n_sentences_with_ngram := 0
+	for sentence in document {
+		if ngram in sentence.map(it.join(ml.ngram_sep)) {
+			n_sentences_with_ngram++
+		}
+	}
+
+	// log base doesnt really matter, as long as it is indeed a logarithm.
+	// I chose 2 because it seems to be the most common log base for computer
+	// science in general.
+	return math.log2(f64(document.len) / f64(n_sentences_with_ngram))
 }
 
 // tf_idf will return the TF * IDF for any given ngram, in a sentence, in a
 // document.
 pub fn tf_idf(ngram []string, sentence [][]string, document [][][]string) f64 {
 	tf := term_frequencies(sentence)[ngram.join(ml.ngram_sep)]
-	idf := inverse_document_frequencies(document)[ngram.join(ml.ngram_sep)]
+	idf := term_idf(ngram, document)
 	return tf * idf
 }

--- a/ml/tokenizer.v
+++ b/ml/tokenizer.v
@@ -6,9 +6,22 @@ const punctuation = (
 	',.[]()[]-=_*;:+><\\"`´~^!?@#$%¨&/|'.split('')
 )
 
-// tokenize_ does the same as tokenize, but does not emit a warning.
-pub fn tokenize_(x string) []string {
-	new_x := x.replace_each(['\n', ' ', '\t', ' ', '\v', ' ', '\r', ' '])
+// remove_punctuation will remove the following characters from the string:
+// `,.[]()[]-=_*;:+><\\"`´~^!?@#$%¨&/|'`
+pub fn remove_punctuation(x string) string {
+	mut new_x := x
+	for punct in (punctuation.join('') + '\'').split('') {
+		new_x = new_x.replace(punct, '')
+	}
+	return new_x
+}
+
+// tokenize will return an array of tokens from the string `x`.
+pub fn tokenize(x string) []string {
+	mut new_x := x
+	for punct in '\n\t\v\r'.split('') {
+		new_x = new_x.replace(punct, '')
+	}
 	mut tokens := []string{}
 
 	mut current_piece := ''
@@ -21,7 +34,9 @@ pub fn tokenize_(x string) []string {
 		}
 
 		if current_char == ' ' {
-			tokens << current_piece
+			if current_piece.len > 0 {
+				tokens << current_piece
+			}
 			current_piece = ''
 			i++
 			continue
@@ -39,17 +54,84 @@ pub fn tokenize_(x string) []string {
 		i++
 	}
 
+	if current_piece.len > 0 {
+		tokens << current_piece
+	}
+
 	return tokens
 }
 
-// tokenize will warn about the lack of complexity of the implementation
-// and will return an array of tokens from the string `x`.
-pub fn tokenize(x string) []string {
-	print(
-		'vsl: Warning: vsl.ml.tokenize is still in development. It is not ' +
-		'very advanced as of now, performing only simple things such as ' +
-		'splitting by spaces and punctuation. To get rid of this message, ' +
-		'run tokenize_(your_string) instead.'
-	)
-	return tokenize_(x)
+// remove_stopwords will remove all tokens included in `stopwords`.
+// If `ignore_case` is true, "THIS" will be considered as "this".
+pub fn remove_stopwords(tokens []string, stopwords []string, ignore_case bool) []string {
+	mut result := []string{}
+	for tok_ in tokens {
+		mut tok := tok_
+		if ignore_case {
+			tok = tok.to_lower()
+		}
+		if tok !in stopwords {
+			result << tok
+		}
+	}
+	return result
+}
+
+// remove_stopwords_en is a wrapper for `remove_stopwords`, passing
+// a default array of some English stopwords.
+pub fn remove_stopwords_en(tokens []string, ignore_case bool) []string {
+	return remove_stopwords(tokens, [
+		'a', 'about', 'above', 'after', 'again', 'against', 'ain',
+		'ain\'t', 'all', 'am', 'an', 'and', 'any', 'are', 'aren',
+		'aren\'t', 'as', 'at', 'be', 'because', 'been', 'before',
+		'being', 'below', 'between', 'both', 'but', 'by', 'can',
+		'couldn', 'couldn\'t', 'd', 'did', 'didn', 'didn\'t', 'do',
+		'does', 'doesn', 'doesn\'t', 'doing', 'don', 'don\'t',
+		'down', 'during', 'each', 'few', 'for', 'from', 'further',
+		'had', 'hadn', 'hadn\'t', 'has', 'hasn', 'hasn\'t', 'have',
+		'haven', 'haven\'t', 'having', 'he', 'her', 'here', 'hers',
+		'herself', 'him', 'himself', 'his', 'how', 'i', 'if', 'in',
+		'into', 'is', 'isn', 'isn\'t', 'it', 'it\'s', 'its', 'itself',
+		'just', 'll', 'm', 'ma', 'me', 'mightn', 'mightn\'t', 'more',
+		'most', 'mustn', 'mustn\'t', 'my', 'myself', 'needn', 'needn\'t',
+		'now', 'o', 'of', 'off', 'on', 'once', 'only', 'or', 'other',
+		'our', 'ours', 'ourselves', 'out', 'over', 'own', 're', 's',
+		'same', 'shan', 'shan\'t', 'she', 'she\'s', 'should', 'should\'ve',
+		'shouldn', 'shouldn\'t', 'so', 'some', 'such', 't', 'than', 'that',
+		'that\'ll', 'the', 'their', 'theirs', 'them', 'themselves', 'then',
+		'there', 'these', 'they', 'this', 'those', 'through', 'to', 'too',
+		'under', 'until', 'up', 've', 'very', 'was', 'wasn', 'wasn\'t', 'we',
+		'were', 'weren', 'weren\'t', 'what', 'when', 'where', 'which',
+		'while', 'who', 'whom', 'why', 'will', 'with', 'won', 'won\'t',
+		'wouldn', 'wouldn\'t', 'y', 'you', 'you\'d', 'you\'ll', 'you\'re',
+		'you\'ve', 'your', 'yours', 'yourself', 'yourselves', 'could',
+		'he\'d', 'he\'ll', 'he\'s', 'here\'s', 'how\'s', 'i\'d', 'i\'ll',
+		'i\'m', 'i\'ve', 'let\'s', 'ought', 'she\'d', 'she\'ll', 'that\'s',
+		'there\'s', 'they\'d', 'they\'ll', 'they\'re', 'they\'ve', 'we\'d',
+		'we\'ll', 'we\'re', 'we\'ve', 'what\'s', 'when\'s', 'where\'s',
+		'who\'s', 'why\'s', 'would'
+	], ignore_case)
+}
+
+// ngrams will return an array of grams containing `n` elements
+// from `tokens`. Example: `ngrams('the apple is red'.split(' '), 3)`
+// will return [['the', 'apple', 'is'], ['apple', 'is', 'red']]
+pub fn ngrams(tokens []string, n int) [][]string {
+	mut grams := [][]string{}
+	if tokens.len == 0 {
+		return grams
+	}
+	if n > tokens.len {
+		return [tokens]
+	}
+	if n <= 0 {
+		errors.vsl_panic(
+			'ml.ngrams expects n to be in the inclusive range [0, tokens.len].',
+			.einval
+		)
+	}
+	for i in 0..(tokens.len - n + 1) {
+		grams << tokens[i..(i + n)]
+	}
+	return grams
 }

--- a/ml/tokenizer.v
+++ b/ml/tokenizer.v
@@ -3,7 +3,7 @@ module ml
 import vsl.errors
 
 const punctuation = (
-	',.[]()[]-=_*;:+><\'\\"`´~^!?@#$%¨&/|'.split('')
+	',.[]()[]-=_*;:+><\\"`´~^!?@#$%¨&/|'.split('')
 )
 
 // tokenize_ does the same as tokenize, but does not emit a warning.

--- a/ml/tokenizer.v
+++ b/ml/tokenizer.v
@@ -6,6 +6,8 @@ const punctuation = (
 	',.[]()[]-=_*;:+><\\"`´~^!?@#$%¨&/|'.split('')
 )
 
+pub const ngram_sep = 'NGRAMSEP'
+
 // remove_punctuation will remove the following characters from the string:
 // `,.[]()[]-=_*;:+><\\"`´~^!?@#$%¨&/|'`
 pub fn remove_punctuation(x string) string {

--- a/ml/tokenizer.v
+++ b/ml/tokenizer.v
@@ -1,0 +1,55 @@
+module ml
+
+import vsl.errors
+
+const punctuation = (
+	',.[]()[]-=_*;:+><\'\\"`´~^!?@#$%¨&/|'.split('')
+)
+
+// tokenize_ does the same as tokenize, but does not emit a warning.
+pub fn tokenize_(x string) []string {
+	new_x := x.replace_each(['\n', ' ', '\t', ' ', '\v', ' ', '\r', ' '])
+	mut tokens := []string{}
+
+	mut current_piece := ''
+	mut i := 0
+	for i < new_x.len {
+		current_char := [new_x[i]].bytestr()
+		if current_piece.len == 0 && current_char == ' ' {
+			i++
+			continue
+		}
+
+		if current_char == ' ' {
+			tokens << current_piece
+			current_piece = ''
+			i++
+			continue
+		}
+
+		if current_char in punctuation {
+			tokens << current_piece
+			tokens << current_char
+			current_piece = ''
+			i += 2
+			continue
+		}
+
+		current_piece += current_char
+		i++
+	}
+
+	return tokens
+}
+
+// tokenize will warn about the lack of complexity of the implementation
+// and will return an array of tokens from the string `x`.
+pub fn tokenize(x string) []string {
+	print(
+		'vsl: Warning: vsl.ml.tokenize is still in development. It is not ' +
+		'very advanced as of now, performing only simple things such as ' +
+		'splitting by spaces and punctuation. To get rid of this message, ' +
+		'run tokenize_(your_string) instead.'
+	)
+	return tokenize_(x)
+}

--- a/vmath/math.v
+++ b/vmath/math.v
@@ -93,3 +93,8 @@ pub fn pow10(n int) f64 {
 pub fn sincos(x f64) (f64, f64) {
 	return vimpl.sincos(x)
 }
+
+[inline]
+pub fn q_rsqrt(x f64) f64 {
+	return unsafe { vimpl.q_rsqrt(x) }
+}

--- a/vmath/vimpl/q_rsqrt.v
+++ b/vmath/vimpl/q_rsqrt.v
@@ -1,0 +1,12 @@
+module vimpl
+
+[unsafe]
+pub fn q_rsqrt(x f64) f64 {
+	x_half := 0.5 * x
+	mut i := i64(vimpl.f64_bits(x))
+	i = 0x5fe6eb50c7b537a9 - (i >> 1)
+	mut j := vimpl.f64_from_bits(u64(i))
+	j *= (1.5 - x_half * j * j)
+	j *= (1.5 - x_half * j * j)
+	return j
+}

--- a/vmath/vimpl/q_rsqrt_test.v
+++ b/vmath/vimpl/q_rsqrt_test.v
@@ -1,0 +1,18 @@
+module vimpl
+
+import rand
+
+const max_allowed_error = 0.000001
+
+[unsafe]
+fn test_q_rsqrt_random() {
+	for _ in 0..1000 {
+		mut rand_num := 0.0
+		for rand_num == 0.0 {
+			rand_num = rand.f64n(999999.0)
+		}
+		sqrt_a := 1.0 / vimpl.sqrt(rand_num)
+		sqrt_b := vimpl.q_rsqrt(rand_num)
+		assert vimpl.abs(sqrt_a - sqrt_b) <= max_allowed_error
+	}
+}


### PR DESCRIPTION
I have added a few NLP tools that rely on ngrams. These include:
- An adaptation of LancasterStemmer from NLTK's source code (`lancaster_stemmer.v` contains a comment giving all credits to the NLTK Project and Steven Tomcavage);
- A very basic tokenizer based on whitespaces and punctuation;
- A punctuation remover;
- A count vectorizer to turn an array of ngrams into a numeric representation of their frequencies in a sentence;
- A stopword remover using common english stopwords (as well as an implementation to add your own stopwords).
- A TF-IDF implementation for slightly more complex NLP models
I also removed two unused iterator variables from `blas/vlas/level1f64.v` because V warnings were annoying me.
Last but not least, I have added `fn q_rsqrt(x f64) f64` in `vmath/math.v` (wrapper) and `vmath/vimpl/q_rsqrt.v` (actual implementation), as well as a unit test in `vmath/vimpl/q_rsqrt_test.v`.
Keep in mind this unit test compares `q_rsqrt(x)` with the traditional `1.0 / sqrt(x)` approach 1000 times on random numbers from >0 to 999999.0, and if the absolute value of their difference exceeds 0.000001, the test does not pass. To reach a reasonable precision, I used two iterations for the approximation method.