### PR TITLE
Fixes plot/examples/scatter.v and adds fixed range support

### DIFF
--- a/plot/axis.v
+++ b/plot/axis.v
@@ -9,6 +9,7 @@ pub mut:
 	dtick    f64
 	tickvals []f64
 	ticktext []string
+	range    []f64
 }
 
 // AxisTitle handles needed data to render an axis title

--- a/plot/examples/scatter.v
+++ b/plot/examples/scatter.v
@@ -27,11 +27,11 @@ fn main() {
 		x: x
 		y: y
 		mode: 'lines+markers'
-		marker: {
+		marker: plot.Marker{
 			size: []f64{len: x.len, init: 10.}
 			color: []string{len: x.len, init: '#FF0000'}
 		}
-		line: {
+		line: plot.Line{
 			color: '#FF0000'
 		}
 	)

--- a/plot/plotter.py
+++ b/plot/plotter.py
@@ -56,6 +56,13 @@ data = json.load(args.data)
 
 # Read layout json file.
 layout = json.load(args.layout)
+# If there is no range specified, leave it as None
+# and let Plotly handle it.
+for ax in ['x', 'y']:
+    if f'{ax}axis' in layout:
+        if 'range' in layout[f'{ax}axis']:
+            if len(layout[f'{ax}axis']['range']) != 2:
+                layout[f'{ax}axis']['range'] = None
 
 # Map vsl.plot.TraceType enum to Plotly objects.
 type_map = {


### PR DESCRIPTION
This PR allows the user to specify a fixed range for the plot. Sample code:

```v
import vsl.plot

fn main() {
	mut my_vals := [5., 6, 7, 8, 9, 10]
	mut p := plot.Plot{}
	p.add_trace(
		trace_type: .scatter,
		x: my_vals
	)
	p.set_layout(
		xaxis: plot.Axis{
			tickmode: 'linear', // or 'array' if you specify Axis.tickvals and/or ticktext
			range: [0., 15], // lower and upper bounds, inclusive
		}
	)
	p.show() ?
}
```

Did not break anything for `plot/examples`.

I've also fixed scatter.v, that broke when plot.Line and plot.Marker were introduced.