### PR TITLE
la: fix den_solve

### DIFF
--- a/la/densesol.v
+++ b/la/densesol.v
@@ -7,14 +7,14 @@ import vsl.blas
 //   Given:  a ⋅ x = b    find x   such that   x = a⁻¹ ⋅ b
 //
 pub fn den_solve(mut x []f64, a Matrix, b []f64, preserve_a bool) {
-	mut a_ := a
+        mut a_ := a.transpose()
 	if preserve_a {
 		a_ = new_matrix(a.m, a.n)
-		a_.data = a.data.clone()
+                a_.data = a.transpose().data.clone()
 	}
 	for i in 0 .. x.len {
 		x[i] = b[i]
 	}
 	ipiv := []int{len: a_.m}
-	blas.dgesv(a_.m, 1, mut a_.data, a_.m, ipiv, mut x, a_.m)
+	blas.dgesv(a_.m, 1, mut a_.data, a_.m, ipiv, mut x, 1)
 }

--- a/la/densesol_test.v
+++ b/la/densesol_test.v
@@ -1,6 +1,6 @@
 module la
 
-import math
+import vsl.float.float64
 
 const (
 	tol = 1e-12
@@ -11,7 +11,7 @@ fn tolerance_equal(data1 []f64, data2 []f64) bool {
 		return false
 	}
 	for i := 0; i < data1.len; i++ {
-		if math.abs(data1[i] - data2[i]) > la.tol {
+		if !float64.tolerance(data1[i], data2[i], la.tol) {
 			return false
 		}
 	}

--- a/la/densesol_test.v
+++ b/la/densesol_test.v
@@ -1,0 +1,46 @@
+module la
+
+import math
+
+const (
+	tol = 1e-12
+)
+
+fn tolerance_equal(data1 []f64, data2 []f64) bool {
+	if data1.len != data2.len {
+		return false
+	}
+	for i := 0; i < data1.len; i++ {
+		if math.abs(data1[i] - data2[i]) > la.tol {
+			return false
+		}
+	}
+	return true
+}
+
+fn test_den_solve() {
+	// case 1
+	mat1 := matrix_deep2([
+			[1., 0],
+			[0., 2],
+		])
+	b1 := [1., 1]
+	mut x1 := []f64{len: mat1.m}
+	den_solve(mut x1, mat1, b1, false)
+	assert tolerance_equal(x1, [1., 0.5])
+	// case 2
+	mat2 := matrix_deep2([
+		[2., 0, 0, -5.6],
+		[0., 3, 0, 1.2],
+		[0., 0, 4, 4.5],
+		[2., -5, 1.3, 0.2]
+	])
+	b2 := [1., 2., 3., 4.]
+	mut x2 := []f64{len: mat2.m}
+	den_solve(mut x2, mat2, b2, false)
+	assert tolerance_equal(x2, [
+		2.867389875082183, 
+		0.32846811308349777, 
+		-0.20118343195266275, 
+		0.8454963839579225])
+}


### PR DESCRIPTION
Apparently den_solve function to solve Ax=b for x was giving incorrect results because of some issues with the call to blas.dgesv.

Here I propose a couple fixes:
- transpose the A matrix because of the different ordering of the Matrix.data field (col major) vs what blas expects (row major)
- set the "leading dimension of b" argument equal to the number of columns of b instead of rows.

I also added a test to verify that the proposed implementation gives sensible results.