### PR TITLE
Updated compilation time for tests using VSL Plot

### DIFF
--- a/plot/plot.v
+++ b/plot/plot.v
@@ -68,11 +68,13 @@ pub fn (p Plot) show() ? {
 		return errors.error('could not save the layout to a JSON file at ${layout_path}.',
 			.efailed)
 	}
-	result := os.execute('bash $run_path --venv="$venv_path" --data="$data_path" --layout="$layout_path"')
-	if result.exit_code != 0 {
-		return error_with_code(result.output, result.exit_code)
+	$if !test ? {
+		result := os.execute('bash $run_path --venv="$venv_path" --data="$data_path" --layout="$layout_path"')
+		if result.exit_code != 0 {
+			return error_with_code(result.output, result.exit_code)
+		}
+		println(result.output)
 	}
-	println(result.output)
 }
 
 // init will ensure that all dependencies are correctly installed and venv initiallized

--- a/plot/plot_test.v
+++ b/plot/plot_test.v
@@ -1,0 +1,19 @@
+module plot
+
+fn test_bar() {
+	mut plt := new_plot()
+
+	plt.add_trace(
+		trace_type: .bar
+		x_str: ['China', 'India', 'USA', 'Indonesia', 'Pakistan']
+		y: [1411778724.0, 1379217184, 331989449, 271350000, 225200000]
+	)
+	plt.set_layout(
+		title: 'Countries by population'
+	)
+	if _ := plt.show() {
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
It is possible to run tests now using `vsl.plot`. It won't execute the `show` function when running tests.

This fixes #76 