### PR TITLE
noise: remove debug println

### DIFF
--- a/noise/perlin.v
+++ b/noise/perlin.v
@@ -61,7 +61,6 @@ pub fn perlin_many(w int, h int) ?[][]f32 {
 	for i, a in res {
 		for j, _ in a {
 			val := perlin(j, i)?
-			println(f64(val))
 			res[i][j] = val
 		}
 	}


### PR DESCRIPTION
it seems i forgot to remove a println() in the code. naturally, that should not be there.