### PR TITLE
`prime`: optimize the `is_prime` function and fix a typo

### DIFF
--- a/prime/prime.v
+++ b/prime/prime.v
@@ -8,7 +8,7 @@ pub fn is_prime(p int) bool {
 		return false
 	}
 	mut i := 2
-	for i <= p / 2 {
+	for i <= math.floor(p / 2) {
 		rem := p % i
 		if rem != 0 {
 			i++

--- a/prime/prime.v
+++ b/prime/prime.v
@@ -2,7 +2,7 @@ module prime
 
 import math
 
-// is_prime returns is an int is prime (deterministically)
+// is_prime returns if an int is prime (deterministically)
 pub fn is_prime(p int) bool {
 	if p < 2 {
 		return false

--- a/prime/prime.v
+++ b/prime/prime.v
@@ -8,7 +8,8 @@ pub fn is_prime(p int) bool {
 		return false
 	}
 	mut i := 2
-	for i <= math.floor(p / 2) {
+	max := math.floor(f32(p) / 2)
+	for i <= max {
 		rem := p % i
 		if rem != 0 {
 			i++


### PR DESCRIPTION
It should be safe to round the number down because when rounding it up, the last `i` can never be a divisor of `p` as even 2 * `i` is greater than `p`.

The `prime_test` test now passes more than 2 times faster for me.