### PR TITLE
fix: typo in hypot error message

### DIFF
--- a/fun/hypot.v
+++ b/fun/hypot.v
@@ -21,7 +21,7 @@ pub fn hypot(x f64, y f64) f64 {
 		if max < math.max_f64 / root_term {
 			result = max * root_term
 		} else {
-			errors.vsl_panic('overflow in hypot_e function', .eovrflw)
+			errors.vsl_panic('overflow in hypot function', .eovrflw)
 		}
 	}
 	return result


### PR DESCRIPTION
When an overflow happens in the `hypot` function it shows a wrong error message that indicates `hypot_e` instead of `hypot`.
