### PR TITLE
github: change Environment field to textarea to handle `v doctor` output

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -77,11 +77,10 @@ body:
         Please provide the version of the repository or tool you are using.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: environment
     attributes:
       label: Environment details (OS name and version, etc.)
-      description: |
-        You can use `v doctor` to fill up this section.
+      description: You can use `v doctor` to fill up this section.
     validations:
-        required: true
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -53,9 +53,10 @@ body:
         Please provide the version of the repository or tool you are using.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: environment
     attributes:
       label: Environment details (OS name and version, etc.)
+      description: You can use `v doctor` to fill up this section.
     validations:
-        required: true
+      required: true


### PR DESCRIPTION
Field suggested using v doctor output, but only gave a single line input. This changes the input to a textarea to handle the full output of the tool.