### PR TITLE
add HDF5 support

### DIFF
--- a/examples/hdf5_relax/main.v
+++ b/examples/hdf5_relax/main.v
@@ -7,7 +7,7 @@ import math
 fn main() {
 	mut linedata := []f64{len: 21}
 	mut newv := 0.0
-	hdffile := c'ex1_hdffile.h5'
+	hdffile := 'ex1_hdffile.h5'
 	mut rounds := i32(0)
 
 	linedata[0] = -2.0

--- a/examples/hdf5_relax/main.v
+++ b/examples/hdf5_relax/main.v
@@ -1,0 +1,38 @@
+import hdf5
+import math
+
+#flag -I/usr/local/include
+#flag -L/usr/local/lib
+
+// ex1
+// A simple 1d relaxation problem.  Write the results
+// and two attributes of the calculation to an HDF5 file.
+// To see the results, use `h5dump ex1_hdffile.h5`
+fn main() {
+	mut linedata := []f64{len: 21}
+	mut newv := f64(0)
+	hdffile := c'ex1_hdffile.h5'
+	mut rounds := i32(0)
+
+	linedata[0] = f64(-2.0)
+	linedata[20] = f64(3.0)
+	mut maxdiff := f64(0.0)
+
+	for loop in 0 .. 1000 {
+		maxdiff = -math.max_f64
+		for i in 1 .. linedata.len - 1 {
+			newv = (linedata[i - 1] + linedata[i] + linedata[i + 1]) / 3.00
+			maxdiff = math.max(maxdiff, math.abs(newv - linedata[i]))
+			linedata[i] = newv
+		}
+		rounds = loop
+		if maxdiff < 0.0001 {
+			break
+		}
+	}
+	f := hdf5.new_file(hdffile)?
+	f.write_dataset1d(c'linedata', linedata)?
+	f.write_attribute(c'linedata', c'rounds', rounds)?
+	f.write_attribute(c'linedata', c'maxdiff', maxdiff)?
+	f.close()
+}

--- a/examples/hdf5_relax/main.v
+++ b/examples/hdf5_relax/main.v
@@ -1,22 +1,18 @@
-import hdf5
+import vsl.hdf5
 import math
 
-#flag -I/usr/local/include
-#flag -L/usr/local/lib
-
-// ex1
 // A simple 1d relaxation problem.  Write the results
 // and two attributes of the calculation to an HDF5 file.
 // To see the results, use `h5dump ex1_hdffile.h5`
 fn main() {
 	mut linedata := []f64{len: 21}
-	mut newv := f64(0)
+	mut newv := 0.0
 	hdffile := c'ex1_hdffile.h5'
 	mut rounds := i32(0)
 
-	linedata[0] = f64(-2.0)
-	linedata[20] = f64(3.0)
-	mut maxdiff := f64(0.0)
+	linedata[0] = -2.0
+	linedata[20] = 3.0
+	mut maxdiff := 0.0
 
 	for loop in 0 .. 1000 {
 		maxdiff = -math.max_f64
@@ -31,8 +27,8 @@ fn main() {
 		}
 	}
 	f := hdf5.new_file(hdffile)?
-	f.write_dataset1d(c'linedata', linedata)?
-	f.write_attribute(c'linedata', c'rounds', rounds)?
-	f.write_attribute(c'linedata', c'maxdiff', maxdiff)?
+	f.write_dataset1d('linedata', linedata)?
+	f.write_attribute('linedata', 'rounds', rounds)?
+	f.write_attribute('linedata', 'maxdiff', maxdiff)?
 	f.close()
 }

--- a/hdf5/README.md
+++ b/hdf5/README.md
@@ -1,0 +1,141 @@
+# HDF5
+
+The functions described in this chapter will read or write data to
+a file in the [HDF5](https://hdfgroup.org) format.  These contain
+`datasets` together with a set of `attributes` for each dataset.
+
+Datasets are arranged in a heirarchical name space similar to Unix
+file system.  Each namespace is called a `group`.  Datasets are
+stored in a group in an area of the file called a `dataspace`.
+
+This library simplifies much of this and supports:
+
+- Datasets consisting of a vector ([]i64, []f64, etc).
+- Datasets consisting of a 2-d array ([][]u8, [][]i16, etc).
+- Datasets consisting of a 3-d array ([][][]u32, [][][]f32, etc).
+- Any number of attributes for each dataset (int, []f64, string, etc).
+  Attributes can be scalars or vectors. These are often metadata
+  of the dataset describing how it was acquired or created.
+
+Currently we do not support:
+
+- Writing to groups other than "/" (which is the default)
+- Datasets of arrays of strings.
+- Compound data structures (akin to `struct`).
+- Images or tables.
+- Compression.
+- Distributed datasets (pointers to other HDF5 files).
+- Parallel reading or writing.
+
+The functions described in this chapter are declared in the module `vsl.hdf5`
+
+## ToDo List
+
+Fixing the error processing arrangement, which is currently a mix of
+option and result types.
+
+Fix the memory consumption for writing 2-d or 3-d arrays: currently this uses
+the flatten() function which is a copy operation.
+
+Add more examples.
+
+Add more datatypes, especially images.
+
+Consider adding a file open-for-update function.
+
+Add automatic group paths.
+
+## Usage example
+
+```v
+import hdf5
+import math.stats
+import rand
+
+fn main() {
+	mut linedata := []f64{len: 21}
+	mut meanv := f64(0)
+	hdffile := c'hdffile.h5'
+
+	for i in 0 .. linedata.len {
+		linedata[i] = rand.f64()
+	}
+	meanv = stats.mean(linedata)
+
+	f := hdf5.new_file(hdffile)?
+	f.write_dataset1d(c'/randdata', linedata)?
+	f.write_attribute(c'/randdata', c'mean', meanv)?
+	f.close()
+}
+```
+
+You can view the result with `h5dump hdffile.h5`.
+
+## Functions
+
+```v ignore
+fn new_file(filename &char) ?HDF_File
+```
+
+This function opens a file for writing, truncating it if it already
+exists.
+
+```v ignore
+fn open_file(filename &char) ?HDF_File
+```
+
+This opens an existing file for reading.
+
+```v ignore
+fn close(file_desc HDF_File)
+```
+
+Closes a file opened for reading or writing.
+
+```v ignore
+fn write_dataset1d(dset_name &char, buffer []T) ?HDF5_herr_t
+```
+
+Writes a vector of type T with the dataset name.  Similar routines
+exist for 2d and 3d for types [][]T and [][][]T.
+
+```v ignore
+fn read_dataset1d(dset_name &char, mut dataset []T)
+```
+
+Reads the named dataset into the variable dataset, changing it's size
+as required for the data in the file.  Similar routines
+exist for 2d for types [][]T.
+
+```v ignore
+fn write_attribute(dset_name &char, attr_name &char, buffer T) ?HDF5_herr_t
+```
+
+This writes a scalar number or string under the attr_name and associated with
+the named dataset.  You can add any number of attributes to a dataset.
+
+```v ignore
+fn write_attribute1d(dset_name &char, attr_name &char, buffer []T) ?HDF5_herr_t
+```
+
+This writes a numeric vector with the attr_name and associated with
+the named dataset.  You can add any number of attributes to a dataset.
+
+```v ignore
+fn read_attribute(dset_name &char, attr_name &char, mut buffer T) ?HDF5_herr_t
+```
+
+This reads a scalar attribute (number or string) associated with the dataset.
+
+```v ignore
+fn read_attribute1d(dset_name &char, attr_name &char, mut buffer []T) ?HDF5_herr_t
+```
+
+This reads a numeric vector attribute associated with the dataset. The given
+1d array is changed as required to fit the size of the vector.
+
+
+## References and Further Reading
+
+See the [HDF5](https://hdfgroup.org) website for documentation and examples
+in C or Fortran.

--- a/hdf5/README.md
+++ b/hdf5/README.md
@@ -48,14 +48,14 @@ Add automatic group paths.
 ## Usage example
 
 ```v
-import hdf5
+import vsl.hdf5
 import math.stats
 import rand
 
 fn main() {
 	mut linedata := []f64{len: 21}
-	mut meanv := f64(0)
-	hdffile := c'hdffile.h5'
+	mut meanv := 0.0
+	hdffile := 'hdffile.h5'
 
 	for i in 0 .. linedata.len {
 		linedata[i] = rand.f64()
@@ -63,77 +63,13 @@ fn main() {
 	meanv = stats.mean(linedata)
 
 	f := hdf5.new_file(hdffile)?
-	f.write_dataset1d(c'/randdata', linedata)?
-	f.write_attribute(c'/randdata', c'mean', meanv)?
+	f.write_dataset1d('/randdata', linedata)?
+	f.write_attribute('/randdata', c'mean', meanv)?
 	f.close()
 }
 ```
 
 You can view the result with `h5dump hdffile.h5`.
-
-## Functions
-
-```v ignore
-fn new_file(filename &char) ?HDF_File
-```
-
-This function opens a file for writing, truncating it if it already
-exists.
-
-```v ignore
-fn open_file(filename &char) ?HDF_File
-```
-
-This opens an existing file for reading.
-
-```v ignore
-fn close(file_desc HDF_File)
-```
-
-Closes a file opened for reading or writing.
-
-```v ignore
-fn write_dataset1d(dset_name &char, buffer []T) ?HDF5_herr_t
-```
-
-Writes a vector of type T with the dataset name.  Similar routines
-exist for 2d and 3d for types [][]T and [][][]T.
-
-```v ignore
-fn read_dataset1d(dset_name &char, mut dataset []T)
-```
-
-Reads the named dataset into the variable dataset, changing it's size
-as required for the data in the file.  Similar routines
-exist for 2d for types [][]T.
-
-```v ignore
-fn write_attribute(dset_name &char, attr_name &char, buffer T) ?HDF5_herr_t
-```
-
-This writes a scalar number or string under the attr_name and associated with
-the named dataset.  You can add any number of attributes to a dataset.
-
-```v ignore
-fn write_attribute1d(dset_name &char, attr_name &char, buffer []T) ?HDF5_herr_t
-```
-
-This writes a numeric vector with the attr_name and associated with
-the named dataset.  You can add any number of attributes to a dataset.
-
-```v ignore
-fn read_attribute(dset_name &char, attr_name &char, mut buffer T) ?HDF5_herr_t
-```
-
-This reads a scalar attribute (number or string) associated with the dataset.
-
-```v ignore
-fn read_attribute1d(dset_name &char, attr_name &char, mut buffer []T) ?HDF5_herr_t
-```
-
-This reads a numeric vector attribute associated with the dataset. The given
-1d array is changed as required to fit the size of the vector.
-
 
 ## References and Further Reading
 

--- a/hdf5/_cflags.c.v
+++ b/hdf5/_cflags.c.v
@@ -1,0 +1,14 @@
+module hdf5
+
+#flag linux -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/include/x86_64-linux-gnu/mpi -pthread -I@VMODROOT
+#flag linux -pthread -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi
+#flag darwin -I/usr/local/Cellar/open-mpi/4.0.1_2/include -I@VMODROOT
+#flag darwin -L/usr/local/opt/libevent/lib -L/usr/local/Cellar/open-mpi/4.0.1_2/lib -lmpi
+#flag freebsd -I/usr/local/include -I@VMODROOT
+#flag freebsd -L/usr/local/lib -lmpi
+#flag openbsd -I/usr/local/include 
+#flag openbsd -L/usr/local/lib -lhdf5 -l hdf5_hl
+
+#include <hdf5.h>
+#include <hdf5_hl.h>
+

--- a/hdf5/_cflags.c.v
+++ b/hdf5/_cflags.c.v
@@ -1,14 +1,15 @@
 module hdf5
 
-#flag linux -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/include/x86_64-linux-gnu/mpi -pthread -I@VMODROOT
-#flag linux -pthread -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi
-#flag darwin -I/usr/local/Cellar/open-mpi/4.0.1_2/include -I@VMODROOT
-#flag darwin -L/usr/local/opt/libevent/lib -L/usr/local/Cellar/open-mpi/4.0.1_2/lib -lmpi
+#flag linux -I@VMODROOT
+#flag linux -pthread -lhdf5 -lhdf5_hl
+#flag darwin -I@VMODROOT
+#flag darwin -lhdf5 -lhdf5_hl
 #flag freebsd -I/usr/local/include -I@VMODROOT
-#flag freebsd -L/usr/local/lib -lmpi
-#flag openbsd -I/usr/local/include 
-#flag openbsd -L/usr/local/lib -lhdf5 -l hdf5_hl
+#flag freebsd -L/usr/local/lib
+#flag openbsd -I/usr/local/include
+#flag openbsd -L/usr/local/lib
+#flag -lhdf5
+#flag -lhdf5_hl
 
 #include <hdf5.h>
 #include <hdf5_hl.h>
-

--- a/hdf5/hdf5_nix.c.v
+++ b/hdf5/hdf5_nix.c.v
@@ -3,66 +3,59 @@ module hdf5
 import arrays { flatten }
 import math
 
-#include "hdf5.h"
-#include "hdf5_hl.h"
-#flag -lhdf5
-#flag -lhdf5_hl
+type Hdf5HidT = i64
+type Hdf5HsizeT = u64
+type Hdf5HerrT = int
+type Hdf5ClassT = int
+type Hdf5SizeT = usize
 
-type HDF5_hid_t = i64
-type HDF5_hsize_t = u64
-type HDF5_herr_t = int
-type HDF5_class_t = int
-type HDF5_size_t = usize
+fn C.H5Fcreate(filename &char, flags int, fcpl_id Hdf5HidT, fapl_id Hdf5HidT) Hdf5HidT
+fn C.H5Fopen(filename &char, flags int, fcpl_id Hdf5HidT) Hdf5HidT
 
-type HDF5_filename = voidptr
+fn C.H5Dget_space(dset_id Hdf5HidT) Hdf5HidT
+fn C.H5Dread(dset_id Hdf5HidT, mem_type_id Hdf5HidT, mem_space_id Hdf5HidT, file_space_id Hdf5HidT, dxpl_id Hdf5HidT, buf &voidptr) Hdf5HerrT
 
-fn C.H5Fcreate(filename &char, flags int, fcpl_id HDF5_hid_t, fapl_id HDF5_hid_t) HDF5_hid_t
-fn C.H5Fopen(filename &char, flags int, fcpl_id HDF5_hid_t) HDF5_hid_t
+fn C.H5Dopen2(loc_id Hdf5HidT, dset &char, dapl_id Hdf5HidT) Hdf5HidT
 
-fn C.H5Dget_space(dset_id HDF5_hid_t) HDF5_hid_t
-fn C.H5Dread(dset_id HDF5_hid_t, mem_type_id HDF5_hid_t, mem_space_id HDF5_hid_t, file_space_id HDF5_hid_t, dxpl_id HDF5_hid_t, buf &voidptr) HDF5_herr_t
+fn C.H5LTset_attribute_int(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_uint(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_long(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_ulong(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_short(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_ushort(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_char(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_uchar(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_long_long(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_double(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_float(loc_id Hdf5HidT, name &char, aname &char, buffer &voidptr, bsize Hdf5HsizeT) Hdf5HidT
+fn C.H5LTset_attribute_string(loc_id Hdf5HidT, name &char, aname &char, buffer &char) Hdf5HidT
 
-fn C.H5Dopen2(loc_id HDF5_hid_t, dset &char, dapl_id HDF5_hid_t) HDF5_hid_t
+fn C.H5LTfind_attribute(loc_id Hdf5HidT, aname &char) Hdf5HerrT
 
-fn C.H5LTset_attribute_int(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_uint(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_long(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_ulong(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_short(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_ushort(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_char(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_uchar(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_long_long(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_double(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_float(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
-fn C.H5LTset_attribute_string(loc_id HDF5_hid_t, name &char, aname &char, buffer &char) HDF5_hid_t
+fn C.H5LTget_attribute_ndims(loc_id Hdf5HidT, name &char, aname &char, rank &int) Hdf5HerrT
+fn C.H5LTget_attribute_info(loc_id Hdf5HidT, name &char, aname &char, dims &Hdf5HsizeT, type_class &Hdf5ClassT, type_size &Hdf5SizeT) Hdf5HerrT
+fn C.H5LTget_attribute_double(loc_id Hdf5HidT, name &char, aname &char, buf &f64) Hdf5HerrT
+fn C.H5LTget_attribute_float(loc_id Hdf5HidT, name &char, aname &char, buf &f32) Hdf5HerrT
+fn C.H5LTget_attribute_long(loc_id Hdf5HidT, name &char, aname &char, buf &i64) Hdf5HerrT
+fn C.H5LTget_attribute_int(loc_id Hdf5HidT, name &char, aname &char, buf &int) Hdf5HerrT
+fn C.H5LTget_attribute_short(loc_id Hdf5HidT, name &char, aname &char, buf &i16) Hdf5HerrT
+fn C.H5LTget_attribute_char(loc_id Hdf5HidT, name &char, aname &char, buf &i8) Hdf5HerrT
+fn C.H5LTget_attribute_ulong(loc_id Hdf5HidT, name &char, aname &char, buf &u64) Hdf5HerrT
+fn C.H5LTget_attribute_uint(loc_id Hdf5HidT, name &char, aname &char, buf &u32) Hdf5HerrT
+fn C.H5LTget_attribute_ushort(loc_id Hdf5HidT, name &char, aname &char, buf &u16) Hdf5HerrT
+fn C.H5LTget_attribute_uchar(loc_id Hdf5HidT, name &char, aname &char, buf &u8) Hdf5HerrT
+fn C.H5LTget_attribute_string(loc_id Hdf5HidT, name &char, aname &char, buf &voidptr) Hdf5HerrT
 
-fn C.H5LTfind_attribute(loc_id HDF5_hid_t, aname &char) HDF5_herr_t
+fn C.H5LTmake_dataset(loc_id Hdf5HidT, dset_name &char, rank int, dims []Hdf5HsizeT, type_id Hdf5HidT, buffer &voidptr) Hdf5HerrT
 
-fn C.H5LTget_attribute_ndims(loc_id HDF5_hid_t, name &char, aname &char, rank &int) HDF5_herr_t
-fn C.H5LTget_attribute_info(loc_id HDF5_hid_t, name &char, aname &char, dims &HDF5_hsize_t, type_class &HDF5_class_t, type_size &HDF5_size_t) HDF5_herr_t
-fn C.H5LTget_attribute_double(loc_id HDF5_hid_t, name &char, aname &char, buf &f64) HDF5_herr_t
-fn C.H5LTget_attribute_float(loc_id HDF5_hid_t, name &char, aname &char, buf &f32) HDF5_herr_t
-fn C.H5LTget_attribute_long(loc_id HDF5_hid_t, name &char, aname &char, buf &i64) HDF5_herr_t
-fn C.H5LTget_attribute_int(loc_id HDF5_hid_t, name &char, aname &char, buf &int) HDF5_herr_t
-fn C.H5LTget_attribute_short(loc_id HDF5_hid_t, name &char, aname &char, buf &i16) HDF5_herr_t
-fn C.H5LTget_attribute_char(loc_id HDF5_hid_t, name &char, aname &char, buf &i8) HDF5_herr_t
-fn C.H5LTget_attribute_ulong(loc_id HDF5_hid_t, name &char, aname &char, buf &u64) HDF5_herr_t
-fn C.H5LTget_attribute_uint(loc_id HDF5_hid_t, name &char, aname &char, buf &u32) HDF5_herr_t
-fn C.H5LTget_attribute_ushort(loc_id HDF5_hid_t, name &char, aname &char, buf &u16) HDF5_herr_t
-fn C.H5LTget_attribute_uchar(loc_id HDF5_hid_t, name &char, aname &char, buf &u8) HDF5_herr_t
-fn C.H5LTget_attribute_string(loc_id HDF5_hid_t, name &char, aname &char, buf &voidptr) HDF5_herr_t
+fn C.H5LTget_dataset_ndims(loc_id Hdf5HidT, name &char, rank &int) Hdf5HerrT
+fn C.H5LTget_dataset_info(loc_id Hdf5HidT, name &char, dims &Hdf5HsizeT, class_id &Hdf5ClassT, type_size &Hdf5SizeT) Hdf5HerrT
+fn C.H5LTread_dataset(loc_id Hdf5HidT, name &char, type_id Hdf5HidT, buffer &voidptr) Hdf5HerrT
 
-fn C.H5LTmake_dataset(loc_id HDF5_hid_t, dset_name &char, rank int, dims []HDF5_hsize_t, type_id HDF5_hid_t, buffer &voidptr) HDF5_herr_t
-
-fn C.H5LTget_dataset_ndims(loc_id HDF5_hid_t, name &char, rank &int) HDF5_herr_t
-fn C.H5LTget_dataset_info(loc_id HDF5_hid_t, name &char, dims &HDF5_hsize_t, class_id &HDF5_class_t, type_size &HDF5_size_t) HDF5_herr_t
-fn C.H5LTread_dataset(loc_id HDF5_hid_t, name &char, type_id HDF5_hid_t, buffer &voidptr) HDF5_herr_t
-
-fn C.H5Aclose(dset_id HDF5_hid_t) HDF5_herr_t
-fn C.H5Dclose(dset_id HDF5_hid_t) HDF5_herr_t
-fn C.H5Sclose(dset_id HDF5_hid_t) HDF5_herr_t
-fn C.H5Fclose(file_id HDF5_hid_t) HDF5_herr_t
+fn C.H5Aclose(dset_id Hdf5HidT) Hdf5HerrT
+fn C.H5Dclose(dset_id Hdf5HidT) Hdf5HerrT
+fn C.H5Sclose(dset_id Hdf5HidT) Hdf5HerrT
+fn C.H5Fclose(file_id Hdf5HidT) Hdf5HerrT
 
 fn make1type[T](a int) []T {
 	return []T{len: a}
@@ -79,7 +72,7 @@ fn make3type[T](a int, b int, c int) [][][]T {
 // hdftype is a Templated function to convert a type to an external const
 // It maps the V type name to an HDF5 type name (f64 -> C.H5T_IEEE_F64LE).
 // Not valid for read with Big Endian architectures (SPARC, some POWER machines)
-fn hdftype[T](x T) HDF5_hid_t {
+fn hdftype[T](x T) Hdf5HidT {
 	$if T is f64 {
 		return C.H5T_IEEE_F64LE
 	} $else $if T is f32 {
@@ -111,15 +104,16 @@ fn hdftype[T](x T) HDF5_hid_t {
 	return C.H5T_STD_U8LE
 }
 
-pub struct HDF_File {
+pub struct HdfFile {
 mut:
-	filedesc HDF5_hid_t
+	filedesc Hdf5HidT
 }
 
 // new_file creates a new HDF5 file, or truncates an existing file.
-pub fn new_file(filename &char) ?HDF_File {
-	mut f := HDF_File{
-		filedesc: C.H5Fcreate(unsafe { filename }, C.H5F_ACC_TRUNC, C.H5P_DEFAULT, C.H5P_DEFAULT)
+pub fn new_file(filename string) ?HdfFile {
+	mut f := HdfFile{
+		filedesc: C.H5Fcreate(unsafe { filename.str }, C.H5F_ACC_TRUNC, C.H5P_DEFAULT,
+			C.H5P_DEFAULT)
 	}
 	return f
 }
@@ -127,113 +121,122 @@ pub fn new_file(filename &char) ?HDF_File {
 // WRITERS
 
 // write_dataset1d writes a 1-d numeric array (vector) to a named HDF5 dataset in an HDF5 file.
-pub fn (f &HDF_File) write_dataset1d[T](dset_name &char, buffer []T) ?HDF5_herr_t {
+pub fn (f &HdfFile) write_dataset1d[T](dset_name string, buffer []T) ?Hdf5HerrT {
 	rank := int(1)
 	dims := [i64(buffer.len)]
 	dtype := hdftype(buffer[0])
-	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name, rank, unsafe { dims.data },
+	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name.str, rank, unsafe { dims.data },
 		dtype, unsafe { buffer.data })
 	return errc
 }
 
 // write_dataset2d writes a 2-d numeric array to a named HDF5 dataset in an HDF5 file.
 // Note: creates a temporary copy of the array.
-pub fn (f &HDF_File) write_dataset2d[T](dset_name &char, buffer [][]T) ?HDF5_herr_t {
+pub fn (f &HdfFile) write_dataset2d[T](dset_name string, buffer [][]T) ?Hdf5HerrT {
 	rank := int(2)
 	dims := [i64(buffer.len), buffer[0].len]
 	dtype := hdftype(buffer[0][0])
-	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name, rank, unsafe { dims.data },
+	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name.str, rank, unsafe { dims.data },
 		dtype, unsafe { flatten(buffer).data })
 	return errc
 }
 
 // write_dataset3d writes a numeric 3-d array (layers of 2-d arrays) to a named HDF5 dataset in an HDF5 file.
 // Note: creates a temporary copy of the array.
-pub fn (f &HDF_File) write_dataset3d[T](dset_name &char, buffer [][][]T) ?HDF5_herr_t {
+pub fn (f &HdfFile) write_dataset3d[T](dset_name string, buffer [][][]T) ?Hdf5HerrT {
 	rank := int(3)
 	dims := [i64(buffer.len), buffer[0].len, buffer[0][0].len]
 	dtype := hdftype(buffer[0][0][0])
-	// must flatten<T> else V cannot guess correctly
-	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name, rank, unsafe { dims.data },
+	// must flatten[T] else V cannot guess correctly
+	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name.str, rank, unsafe { dims.data },
 		dtype, unsafe { flatten[T](flatten(buffer)).data })
 	return errc
 }
 
 // write_attribute1d adds a named 1-d numeric array (vector) attribute to a named HDF5 dataset.
-pub fn (f &HDF_File) write_attribute1d[T](dset_name &char, attr_name &char, buffer []T) ?HDF5_herr_t {
+pub fn (f &HdfFile) write_attribute1d[T](dset_name string, attr_name string, buffer []T) ?Hdf5HerrT {
 	$if T is f64 {
-		return C.H5LTset_attribute_double(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_double(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is f32 {
-		return C.H5LTset_attribute_float(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_float(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is i64 {
-		return C.H5LTset_attribute_long_long(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
-			u64(buffer.len))
+		return C.H5LTset_attribute_long_long(f.filedesc, dset_name.str, attr_name.str,
+			unsafe { buffer.data }, u64(buffer.len))
 	} $else $if T is int {
-		return C.H5LTset_attribute_int(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_int(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is i16 {
-		return C.H5LTset_attribute_short(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_short(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is i8 {
-		return C.H5LTset_attribute_char(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_char(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is u64 {
-		return C.H5LTset_attribute_ulong(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_ulong(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is u32 {
-		return C.H5LTset_attribute_uint(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_uint(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is u16 {
-		return C.H5LTset_attribute_ushort(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_ushort(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else $if T is u8 {
-		return C.H5LTset_attribute_uchar(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+		return C.H5LTset_attribute_uchar(f.filedesc, dset_name.str, attr_name.str, unsafe { buffer.data },
 			u64(buffer.len))
 	} $else {
-		return HDF5_herr_t(-1)
+		return Hdf5HerrT(-1)
 	}
 }
 
 // write_attribute adds a named scalar attribute to a named HDF5 dataset.
 //   This is a helper function to avoid an array temporary; it writes a single element vector.
 //   It also supports writing a string attribute.
-pub fn (f &HDF_File) write_attribute[T](dset_name &char, attr_name &char, buffer T) ?HDF5_herr_t {
+pub fn (f &HdfFile) write_attribute[T](dset_name string, attr_name string, buffer T) ?Hdf5HerrT {
 	$if T is f64 {
-		return C.H5LTset_attribute_double(f.filedesc, dset_name, attr_name, &buffer, u64(1))
-	} $else $if T is f32 {
-		return C.H5LTset_attribute_float(f.filedesc, dset_name, attr_name, &buffer, u64(1))
-	} $else $if T is i64 {
-		return C.H5LTset_attribute_long_long(f.filedesc, dset_name, attr_name, &buffer,
+		return C.H5LTset_attribute_double(f.filedesc, dset_name.str, attr_name.str, &buffer,
 			u64(1))
+	} $else $if T is f32 {
+		return C.H5LTset_attribute_float(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
+	} $else $if T is i64 {
+		return C.H5LTset_attribute_long_long(f.filedesc, dset_name.str, attr_name.str,
+			&buffer, u64(1))
 	} $else $if T is i32 {
-		return C.H5LTset_attribute_int(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_int(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is i16 {
-		return C.H5LTset_attribute_short(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_short(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is i8 {
-		return C.H5LTset_attribute_char(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_char(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is u64 {
-		return C.H5LTset_attribute_ulong(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_ulong(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is u32 {
-		return C.H5LTset_attribute_uint(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_uint(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is u16 {
-		return C.H5LTset_attribute_ushort(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_ushort(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is u8 {
-		return C.H5LTset_attribute_uchar(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+		return C.H5LTset_attribute_uchar(f.filedesc, dset_name.str, attr_name.str, &buffer,
+			u64(1))
 	} $else $if T is string {
-		return C.H5LTset_attribute_string(f.filedesc, dset_name, attr_name, &char(buffer.str))
+		return C.H5LTset_attribute_string(f.filedesc, dset_name.str, attr_name.str, &char(buffer.str))
 	} $else {
-		return HDF5_herr_t(-1)
+		return Hdf5HerrT(-1)
 	}
 }
 
 // READERS
 
 // open_file opens an existing HDF5 file
-pub fn open_file(filename &char) ?HDF_File {
-	mut f := HDF_File{
-		filedesc: C.H5Fopen(unsafe { filename }, C.H5F_ACC_RDONLY, C.H5P_DEFAULT)
+pub fn open_file(filename string) ?HdfFile {
+	mut f := HdfFile{
+		filedesc: C.H5Fopen(unsafe { filename.str }, C.H5F_ACC_RDONLY, C.H5P_DEFAULT)
 	}
 	return f
 }
@@ -241,18 +244,18 @@ pub fn open_file(filename &char) ?HDF_File {
 // read_dataset1d reads a 1-d numeric array (vector) from a named HDF5 dataset in an HDF5 file.
 //   Replaces the value of the array.
 //   Maximum dimension is math.max_i32 or less (this is checked).
-pub fn (f &HDF_File) read_dataset1d[T](dset_name &char, mut dataset []T) {
+pub fn (f &HdfFile) read_dataset1d[T](dset_name string, mut dataset []T) {
 	mut rank := 0
-	mut class_id := HDF5_class_t(0)
-	mut type_size := HDF5_size_t(0)
+	mut class_id := Hdf5ClassT(0)
+	mut type_size := Hdf5SizeT(0)
 
-	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name, &rank)
+	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name.str, &rank)
 	assert errc >= 0
 	assert rank == 1
 
-	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
-	errc = C.H5LTget_dataset_info(f.filedesc, dset_name, unsafe { curdims.data }, &class_id,
-		&type_size)
+	mut curdims := []Hdf5HsizeT{len: rank, init: 0}
+	errc = C.H5LTget_dataset_info(f.filedesc, dset_name.str, unsafe { curdims.data },
+		&class_id, &type_size)
 	assert errc >= 0
 	assert curdims[0] > 0
 	assert curdims[0] < math.max_i32
@@ -260,7 +263,7 @@ pub fn (f &HDF_File) read_dataset1d[T](dset_name &char, mut dataset []T) {
 	dtype := hdftype(dataset[0])
 	// note: V dims are int while hdf5 dims are u64
 	mut x := []T{len: int(curdims[0])}
-	errc = C.H5LTread_dataset(f.filedesc, dset_name, dtype, unsafe { x.data })
+	errc = C.H5LTread_dataset(f.filedesc, dset_name.str, dtype, unsafe { x.data })
 	assert errc >= 0
 
 	unsafe {
@@ -272,19 +275,18 @@ pub fn (f &HDF_File) read_dataset1d[T](dset_name &char, mut dataset []T) {
 //   Replaces the value of the array.
 //   Maximum of any dimension is math.max_i32 or less (this is checked).
 //   Maximum total elements is also math.max_i32.
-pub fn (f &HDF_File) read_dataset2d[T](dset_name &char, mut dataset [][]T) {
-	adset := unsafe { tos5(dset_name) }
+pub fn (f &HdfFile) read_dataset2d[T](dset_name string, mut dataset [][]T) {
 	mut rank := 0
-	mut class_id := HDF5_class_t(0)
-	mut type_size := HDF5_size_t(0)
+	mut class_id := Hdf5ClassT(0)
+	mut type_size := Hdf5SizeT(0)
 
-	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name, &rank)
+	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name.str, &rank)
 	assert errc >= 0
 	assert rank == 2
 
-	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
-	errc = C.H5LTget_dataset_info(f.filedesc, dset_name, unsafe { curdims.data }, &class_id,
-		&type_size)
+	mut curdims := []Hdf5HsizeT{len: rank, init: 0}
+	errc = C.H5LTget_dataset_info(f.filedesc, dset_name.str, unsafe { curdims.data },
+		&class_id, &type_size)
 	assert errc >= 0
 	assert curdims[0] > 0
 	assert curdims[1] > 0
@@ -294,11 +296,11 @@ pub fn (f &HDF_File) read_dataset2d[T](dset_name &char, mut dataset [][]T) {
 	dtype := hdftype(dataset[0][0])
 	mut y := make1type[T](int(curdims[0] * curdims[1]))
 
-	errc = C.H5LTread_dataset(f.filedesc, dset_name, dtype, unsafe { y.data })
+	errc = C.H5LTread_dataset(f.filedesc, dset_name.str, dtype, unsafe { y.data })
 	assert errc >= 0
 
 	dataset = reshape(y, curdims) or {
-		println(' dataset ${adset} reshape failed')
+		println(' dataset ${dset_name} reshape failed')
 		return
 	}
 }
@@ -307,19 +309,18 @@ pub fn (f &HDF_File) read_dataset2d[T](dset_name &char, mut dataset [][]T) {
 //   Replaces the value of the array with correctly dimensioned array.
 //   Maximum of any dimension is math.max_i32 or less (this is checked).
 //   Maximum total elements is also math.max_i32.
-pub fn (f &HDF_File) read_dataset3d[T](dset_name &char, mut dataset [][][]T) {
+pub fn (f &HdfFile) read_dataset3d[T](dset_name string, mut dataset [][][]T) {
 	mut rank := 0
-	mut class_id := HDF5_class_t(0)
-	mut type_size := HDF5_size_t(0)
-	adset := unsafe { tos5(dset_name) }
+	mut class_id := Hdf5ClassT(0)
+	mut type_size := Hdf5SizeT(0)
 
-	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name, &rank)
+	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name.str, &rank)
 	assert errc >= 0
 	assert rank == 3
 
-	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
-	errc = C.H5LTget_dataset_info(f.filedesc, dset_name, unsafe { curdims.data }, &class_id,
-		&type_size)
+	mut curdims := []Hdf5HsizeT{len: rank, init: 0}
+	errc = C.H5LTget_dataset_info(f.filedesc, dset_name.str, unsafe { curdims.data },
+		&class_id, &type_size)
 	assert errc >= 0
 	assert curdims[0] > 0
 	assert curdims[1] > 0
@@ -331,20 +332,20 @@ pub fn (f &HDF_File) read_dataset3d[T](dset_name &char, mut dataset [][][]T) {
 	dtype := hdftype(dataset[0][0][0])
 	mut y := make1type[T](int(curdims[0] * curdims[1] * curdims[2]))
 
-	errc = C.H5LTread_dataset(f.filedesc, dset_name, dtype, unsafe { y.data })
+	errc = C.H5LTread_dataset(f.filedesc, dset_name.str, dtype, unsafe { y.data })
 	assert errc >= 0
 
 	dataset = reshape3(y, curdims) or {
-		println(' dataset ${adset} reshape failed')
+		println(' dataset ${dset_name} reshape failed')
 		return
 	}
 }
 
 // reshape returns [][]x using []y and intended dimensions.
 // y.len() == product(dimensions) else error.
-fn reshape[T](y []T, dims []HDF5_hsize_t) ![][]T {
-	mut proddims := HDF5_hsize_t(1)
-	leny := HDF5_hsize_t(u64(y.len))
+fn reshape[T](y []T, dims []Hdf5HsizeT) ![][]T {
+	mut proddims := Hdf5HsizeT(1)
+	leny := Hdf5HsizeT(u64(y.len))
 	for i in 0 .. dims.len {
 		proddims = proddims * dims[i]
 	}
@@ -368,9 +369,9 @@ fn reshape[T](y []T, dims []HDF5_hsize_t) ![][]T {
 
 // reshape3 returns [][][]x using []y and intended dimensions.
 // y.len() == product(dimensions) else error.
-fn reshape3[T](y []T, dims []HDF5_hsize_t) ![][][]T {
-	mut proddims := HDF5_hsize_t(1)
-	leny := HDF5_hsize_t(u64(y.len))
+fn reshape3[T](y []T, dims []Hdf5HsizeT) ![][][]T {
+	mut proddims := Hdf5HsizeT(1)
+	leny := Hdf5HsizeT(u64(y.len))
 	for i in 0 .. dims.len {
 		proddims = proddims * dims[i]
 	}
@@ -398,17 +399,17 @@ fn reshape3[T](y []T, dims []HDF5_hsize_t) ![][][]T {
 // getattr_class_size reads back the HDF5 class (float, int, string) and size (1, 2, 4, 8) of a scalar attribute.
 // This is a helper function for read_attribute<T> for a scalar or read_attribute1d<T> for a vector.
 // Assumes the attribute and dataset exist.
-fn (f &HDF_File) getattr_class_size(dset_name &char, attr_name &char) (HDF5_class_t, HDF5_size_t) {
+fn (f &HdfFile) getattr_class_size(dset_name string, attr_name string) (Hdf5ClassT, Hdf5SizeT) {
 	mut rank := int(0)
-	mut type_class := HDF5_class_t(0)
-	mut type_size := HDF5_size_t(0)
+	mut type_class := Hdf5ClassT(0)
+	mut type_size := Hdf5SizeT(0)
 
-	mut errc := C.H5LTget_attribute_ndims(f.filedesc, dset_name, attr_name, &rank)
+	mut errc := C.H5LTget_attribute_ndims(f.filedesc, dset_name.str, attr_name.str, &rank)
 	assert errc >= 0
 	assert rank == 1
 
-	mut curdims := []HDF5_hsize_t{len: if rank == 1 { rank } else { 1 }, init: 0}
-	errc = C.H5LTget_attribute_info(f.filedesc, dset_name, attr_name, unsafe { curdims.data },
+	mut curdims := []Hdf5HsizeT{len: if rank == 1 { rank } else { 1 }, init: 0}
+	errc = C.H5LTget_attribute_info(f.filedesc, dset_name.str, attr_name.str, unsafe { curdims.data },
 		&type_class, &type_size)
 	assert errc >= 0
 	assert curdims[0] >= 1
@@ -416,8 +417,8 @@ fn (f &HDF_File) getattr_class_size(dset_name &char, attr_name &char) (HDF5_clas
 }
 
 // checkdsetattr verifies dataset and attribute exist
-fn (f &HDF_File) checkdsetattr(dset_name &char, attr_name &char) bool {
-	mut dset_id := C.H5Dopen2(f.filedesc, dset_name, C.H5P_DEFAULT)
+fn (f &HdfFile) checkdsetattr(dset_name string, attr_name string) bool {
+	mut dset_id := C.H5Dopen2(f.filedesc, dset_name.str, C.H5P_DEFAULT)
 	defer {
 		C.H5Dclose(dset_id)
 	}
@@ -425,7 +426,7 @@ fn (f &HDF_File) checkdsetattr(dset_name &char, attr_name &char) bool {
 		return false
 	}
 
-	errc := C.H5LTfind_attribute(dset_id, attr_name)
+	errc := C.H5LTfind_attribute(dset_id, attr_name.str)
 	if errc == 0 {
 		return false
 	} else {
@@ -435,16 +436,16 @@ fn (f &HDF_File) checkdsetattr(dset_name &char, attr_name &char) bool {
 
 // checktype verifies name, class and type-size for an attribute.
 // Returns true only if the name exists and class and type-size match.
-fn (f &HDF_File) checktype(dset_name &char, attr_name &char, type_class HDF5_class_t, type_size HDF5_size_t) bool {
-	mut x_type_class := HDF5_class_t(0)
-	mut x_type_size := HDF5_size_t(0)
+fn (f &HdfFile) checktype(dset_name string, attr_name string, type_class Hdf5ClassT, type_size Hdf5SizeT) bool {
+	mut x_type_class := Hdf5ClassT(0)
+	mut x_type_size := Hdf5SizeT(0)
 
-	mut dset_id := C.H5Dopen2(f.filedesc, dset_name, C.H5P_DEFAULT)
+	mut dset_id := C.H5Dopen2(f.filedesc, dset_name.str, C.H5P_DEFAULT)
 	defer {
 		C.H5Dclose(dset_id)
 	}
 
-	errc := C.H5LTfind_attribute(dset_id, attr_name)
+	errc := C.H5LTfind_attribute(dset_id, attr_name.str)
 
 	if errc == 0 {
 		return false
@@ -462,47 +463,45 @@ fn (f &HDF_File) checktype(dset_name &char, attr_name &char, type_class HDF5_cla
 // This is a helper function to check existance of and process string copies.
 // Strings are a special case since the length varies.
 // Assumes the dataset exists but does check the attribute exists.
-fn (f &HDF_File) getstringattr(dset_name &char, attr_name &char) !string {
-	mut type_class := HDF5_class_t(0)
-	mut type_size := HDF5_size_t(0)
-	mut curdims := HDF5_hsize_t(0)
+fn (f &HdfFile) getstringattr(dset_name string, attr_name string) !string {
+	mut type_class := Hdf5ClassT(0)
+	mut type_size := Hdf5SizeT(0)
+	mut curdims := Hdf5HsizeT(0)
 
-	adset := unsafe { tos5(dset_name) }
-	aattr := unsafe { tos5(attr_name) }
-	mut dset_id := C.H5Dopen2(f.filedesc, dset_name, C.H5P_DEFAULT)
+	mut dset_id := C.H5Dopen2(f.filedesc, dset_name.str, C.H5P_DEFAULT)
 	defer {
 		C.H5Dclose(dset_id)
 	}
 
-	mut errc := C.H5LTfind_attribute(dset_id, attr_name)
+	mut errc := C.H5LTfind_attribute(dset_id, attr_name.str)
 	if errc == 0 {
-		return error(' dataset ${adset} no attribute ${aattr}')
+		return error(' dataset ${dset_name} no attribute ${attr_name}')
 	}
 
 	// we don't use our getattr_class_size() because strings have rank==0 and dims[0]==0
-	errc = C.H5LTget_attribute_info(f.filedesc, dset_name, attr_name, unsafe { &curdims },
+	errc = C.H5LTget_attribute_info(f.filedesc, dset_name.str, attr_name.str, unsafe { &curdims },
 		&type_class, &type_size)
 	assert errc >= 0
 	assert type_class == C.H5T_STRING
 
 	if type_class == C.H5T_STRING {
 		mut buffer := vcalloc(type_size)
-		errc = C.H5LTget_attribute_string(f.filedesc, dset_name, attr_name, buffer)
+		errc = C.H5LTget_attribute_string(f.filedesc, dset_name.str, attr_name.str, buffer)
 		assert errc >= 0
 		vs := unsafe { cstring_to_vstring(buffer) }
 		unsafe {
 			return vs
 		}
 	} else {
-		return error(' dataset ${adset} attribute ${aattr} not a string')
+		return error(' dataset ${dset_name} attribute ${attr_name} not a string')
 	}
 }
 
 // readattribute gets a named scalar attribute from a named HDF5 dataset.
 //   This is a helper function to avoid an array temporary; it gets a single element vector.
 //   It also supports reading a string attribute.
-pub fn (f &HDF_File) read_attribute[T](dset_name &char, attr_name &char, mut attr_value T) ?bool {
-	mut errc := HDF5_herr_t(0)
+pub fn (f &HdfFile) read_attribute[T](dset_name string, attr_name string, mut attr_value T) ?bool {
+	mut errc := Hdf5HerrT(0)
 
 	if !f.checkdsetattr(dset_name, attr_name) {
 		return false
@@ -510,70 +509,79 @@ pub fn (f &HDF_File) read_attribute[T](dset_name &char, attr_name &char, mut att
 
 	$if T is f64 {
 		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 8) {
-			errc = C.H5LTget_attribute_double(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_double(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is f32 {
 		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 4) {
-			errc = C.H5LTget_attribute_float(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_float(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i64 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
-			errc = C.H5LTget_attribute_long(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_long(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i32 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
-			errc = C.H5LTget_attribute_int(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_int(f.filedesc, dset_name.str, attr_name.str, &attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i16 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
-			errc = C.H5LTget_attribute_short(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_short(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i8 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
-			errc = C.H5LTget_attribute_char(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_char(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u64 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
-			errc = C.H5LTget_attribute_ulong(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_ulong(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u32 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
-			errc = C.H5LTget_attribute_uint(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_uint(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u16 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
-			errc = C.H5LTget_attribute_ushort(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_ushort(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u8 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
-			errc = C.H5LTget_attribute_uchar(f.filedesc, dset_name, attr_name, &attr_value)
+			errc = C.H5LTget_attribute_uchar(f.filedesc, dset_name.str, attr_name.str,
+				&attr_value)
 			assert errc >= 0
 			return true
 		}
@@ -593,21 +601,21 @@ pub fn (f &HDF_File) read_attribute[T](dset_name &char, attr_name &char, mut att
 // read_attribute1d reads a 1-d numeric array (vector) from a named HDF5 dataset and named attribute in an HDF5 file.
 //   Replaces the value of the given array.
 //   Maximum dimension is math.max_i32 or less (this is checked).
-pub fn (f &HDF_File) read_attribute1d[T](dset_name &char, attr_name &char, mut attr_value []T) ?bool {
+pub fn (f &HdfFile) read_attribute1d[T](dset_name string, attr_name string, mut attr_value []T) ?bool {
 	mut rank := 0
-	mut class_id := HDF5_class_t(0)
-	mut type_size := HDF5_size_t(0)
+	mut class_id := Hdf5ClassT(0)
+	mut type_size := Hdf5SizeT(0)
 
 	if !f.checkdsetattr(dset_name, attr_name) {
 		return false
 	}
 
-	mut errc := C.H5LTget_attribute_ndims(f.filedesc, dset_name, attr_name, &rank)
+	mut errc := C.H5LTget_attribute_ndims(f.filedesc, dset_name.str, attr_name.str, &rank)
 	assert errc >= 0
 	assert rank == 1
 
-	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
-	errc = C.H5LTget_attribute_info(f.filedesc, dset_name, attr_name, unsafe { curdims.data },
+	mut curdims := []Hdf5HsizeT{len: rank, init: 0}
+	errc = C.H5LTget_attribute_info(f.filedesc, dset_name.str, attr_name.str, unsafe { curdims.data },
 		&class_id, &type_size)
 	assert errc >= 0
 	assert curdims[0] > 0
@@ -621,73 +629,81 @@ pub fn (f &HDF_File) read_attribute1d[T](dset_name &char, attr_name &char, mut a
 	unsafe {
 		attr_value = x
 	}
-
 	$if T is f64 {
 		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 8) {
-			errc = C.H5LTget_attribute_double(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_double(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is f32 {
 		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 4) {
-			errc = C.H5LTget_attribute_float(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_float(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i64 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
-			errc = C.H5LTget_attribute_long(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_long(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i32 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
-			errc = C.H5LTget_attribute_int(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_int(f.filedesc, dset_name.str, attr_name.str, unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i16 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
-			errc = C.H5LTget_attribute_short(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_short(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is i8 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
-			errc = C.H5LTget_attribute_char(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_char(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u64 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
-			errc = C.H5LTget_attribute_ulong(f.filedesc, dset_name, attr_name, attr_value.data)
+			errc = C.H5LTget_attribute_ulong(f.filedesc, dset_name.str, attr_name.str,
+				attr_value.data)
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u32 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
-			errc = C.H5LTget_attribute_uint(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_uint(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u16 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
-			errc = C.H5LTget_attribute_ushort(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_ushort(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
 		return false
 	} $else $if T is u8 {
 		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
-			errc = C.H5LTget_attribute_uchar(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			errc = C.H5LTget_attribute_uchar(f.filedesc, dset_name.str, attr_name.str,
+				unsafe { attr_value.data })
 			assert errc >= 0
 			return true
 		}
@@ -705,6 +721,6 @@ pub fn (f &HDF_File) read_attribute1d[T](dset_name &char, attr_name &char, mut a
 }
 
 // close releases memory resources for HDF5 files.
-pub fn (f &HDF_File) close() {
+pub fn (f &HdfFile) close() {
 	C.H5Fclose(f.filedesc)
 }

--- a/hdf5/hdf5_nix.c.v
+++ b/hdf5/hdf5_nix.c.v
@@ -1,0 +1,710 @@
+module hdf5
+
+import arrays { flatten }
+import math
+
+#include "hdf5.h"
+#include "hdf5_hl.h"
+#flag -lhdf5
+#flag -lhdf5_hl
+
+type HDF5_hid_t = i64
+type HDF5_hsize_t = u64
+type HDF5_herr_t = int
+type HDF5_class_t = int
+type HDF5_size_t = usize
+
+type HDF5_filename = voidptr
+
+fn C.H5Fcreate(filename &char, flags int, fcpl_id HDF5_hid_t, fapl_id HDF5_hid_t) HDF5_hid_t
+fn C.H5Fopen(filename &char, flags int, fcpl_id HDF5_hid_t) HDF5_hid_t
+
+fn C.H5Dget_space(dset_id HDF5_hid_t) HDF5_hid_t
+fn C.H5Dread(dset_id HDF5_hid_t, mem_type_id HDF5_hid_t, mem_space_id HDF5_hid_t, file_space_id HDF5_hid_t, dxpl_id HDF5_hid_t, buf &voidptr) HDF5_herr_t
+
+fn C.H5Dopen2(loc_id HDF5_hid_t, dset &char, dapl_id HDF5_hid_t) HDF5_hid_t
+
+fn C.H5LTset_attribute_int(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_uint(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_long(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_ulong(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_short(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_ushort(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_char(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_uchar(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_long_long(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_double(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_float(loc_id HDF5_hid_t, name &char, aname &char, buffer &voidptr, bsize HDF5_hsize_t) HDF5_hid_t
+fn C.H5LTset_attribute_string(loc_id HDF5_hid_t, name &char, aname &char, buffer &char) HDF5_hid_t
+
+fn C.H5LTfind_attribute(loc_id HDF5_hid_t, aname &char) HDF5_herr_t
+
+fn C.H5LTget_attribute_ndims(loc_id HDF5_hid_t, name &char, aname &char, rank &int) HDF5_herr_t
+fn C.H5LTget_attribute_info(loc_id HDF5_hid_t, name &char, aname &char, dims &HDF5_hsize_t, type_class &HDF5_class_t, type_size &HDF5_size_t) HDF5_herr_t
+fn C.H5LTget_attribute_double(loc_id HDF5_hid_t, name &char, aname &char, buf &f64) HDF5_herr_t
+fn C.H5LTget_attribute_float(loc_id HDF5_hid_t, name &char, aname &char, buf &f32) HDF5_herr_t
+fn C.H5LTget_attribute_long(loc_id HDF5_hid_t, name &char, aname &char, buf &i64) HDF5_herr_t
+fn C.H5LTget_attribute_int(loc_id HDF5_hid_t, name &char, aname &char, buf &int) HDF5_herr_t
+fn C.H5LTget_attribute_short(loc_id HDF5_hid_t, name &char, aname &char, buf &i16) HDF5_herr_t
+fn C.H5LTget_attribute_char(loc_id HDF5_hid_t, name &char, aname &char, buf &i8) HDF5_herr_t
+fn C.H5LTget_attribute_ulong(loc_id HDF5_hid_t, name &char, aname &char, buf &u64) HDF5_herr_t
+fn C.H5LTget_attribute_uint(loc_id HDF5_hid_t, name &char, aname &char, buf &u32) HDF5_herr_t
+fn C.H5LTget_attribute_ushort(loc_id HDF5_hid_t, name &char, aname &char, buf &u16) HDF5_herr_t
+fn C.H5LTget_attribute_uchar(loc_id HDF5_hid_t, name &char, aname &char, buf &u8) HDF5_herr_t
+fn C.H5LTget_attribute_string(loc_id HDF5_hid_t, name &char, aname &char, buf &voidptr) HDF5_herr_t
+
+fn C.H5LTmake_dataset(loc_id HDF5_hid_t, dset_name &char, rank int, dims []HDF5_hsize_t, type_id HDF5_hid_t, buffer &voidptr) HDF5_herr_t
+
+fn C.H5LTget_dataset_ndims(loc_id HDF5_hid_t, name &char, rank &int) HDF5_herr_t
+fn C.H5LTget_dataset_info(loc_id HDF5_hid_t, name &char, dims &HDF5_hsize_t, class_id &HDF5_class_t, type_size &HDF5_size_t) HDF5_herr_t
+fn C.H5LTread_dataset(loc_id HDF5_hid_t, name &char, type_id HDF5_hid_t, buffer &voidptr) HDF5_herr_t
+
+fn C.H5Aclose(dset_id HDF5_hid_t) HDF5_herr_t
+fn C.H5Dclose(dset_id HDF5_hid_t) HDF5_herr_t
+fn C.H5Sclose(dset_id HDF5_hid_t) HDF5_herr_t
+fn C.H5Fclose(file_id HDF5_hid_t) HDF5_herr_t
+
+fn make1type[T](a int) []T {
+	return []T{len: a}
+}
+
+fn make2type[T](a int, b int) [][]T {
+	return [][]T{len: a, init: []T{len: b}}
+}
+
+fn make3type[T](a int, b int, c int) [][][]T {
+	return [][][]T{len: a, init: make2type[T](b, c)}
+}
+
+// hdftype is a Templated function to convert a type to an external const
+// It maps the V type name to an HDF5 type name (f64 -> C.H5T_IEEE_F64LE).
+// Not valid for read with Big Endian architectures (SPARC, some POWER machines)
+fn hdftype[T](x T) HDF5_hid_t {
+	$if T is f64 {
+		return C.H5T_IEEE_F64LE
+	} $else $if T is f32 {
+		return C.H5T_IEEE_F32LE
+	} $else $if T is i64 {
+		return C.H5T_STD_I64LE
+	} $else $if T is i32 { // note i32 is an alias for int
+		return C.H5T_STD_I32LE
+	} $else $if T is int {
+		return C.H5T_STD_I32LE
+	} $else $if T is i16 {
+		return C.H5T_STD_I16LE
+	} $else $if T is i8 {
+		return C.H5T_STD_I8LE
+	} $else $if T is u64 {
+		return C.H5T_STD_U64LE
+	} $else $if T is u32 {
+		return C.H5T_STD_U32LE
+	} $else $if T is u16 {
+		return C.H5T_STD_U16LE
+	} $else $if T is u8 {
+		return C.H5T_STD_U8LE
+	} $else $if T is string {
+		return C.H5T_C_S1
+	} $else {
+		// only at runtime:
+		eprintln('hdf5 unsupported type: ${typeof(x).name}')
+	}
+	return C.H5T_STD_U8LE
+}
+
+pub struct HDF_File {
+mut:
+	filedesc HDF5_hid_t
+}
+
+// new_file creates a new HDF5 file, or truncates an existing file.
+pub fn new_file(filename &char) ?HDF_File {
+	mut f := HDF_File{
+		filedesc: C.H5Fcreate(unsafe { filename }, C.H5F_ACC_TRUNC, C.H5P_DEFAULT, C.H5P_DEFAULT)
+	}
+	return f
+}
+
+// WRITERS
+
+// write_dataset1d writes a 1-d numeric array (vector) to a named HDF5 dataset in an HDF5 file.
+pub fn (f &HDF_File) write_dataset1d[T](dset_name &char, buffer []T) ?HDF5_herr_t {
+	rank := int(1)
+	dims := [i64(buffer.len)]
+	dtype := hdftype(buffer[0])
+	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name, rank, unsafe { dims.data },
+		dtype, unsafe { buffer.data })
+	return errc
+}
+
+// write_dataset2d writes a 2-d numeric array to a named HDF5 dataset in an HDF5 file.
+// Note: creates a temporary copy of the array.
+pub fn (f &HDF_File) write_dataset2d[T](dset_name &char, buffer [][]T) ?HDF5_herr_t {
+	rank := int(2)
+	dims := [i64(buffer.len), buffer[0].len]
+	dtype := hdftype(buffer[0][0])
+	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name, rank, unsafe { dims.data },
+		dtype, unsafe { flatten(buffer).data })
+	return errc
+}
+
+// write_dataset3d writes a numeric 3-d array (layers of 2-d arrays) to a named HDF5 dataset in an HDF5 file.
+// Note: creates a temporary copy of the array.
+pub fn (f &HDF_File) write_dataset3d[T](dset_name &char, buffer [][][]T) ?HDF5_herr_t {
+	rank := int(3)
+	dims := [i64(buffer.len), buffer[0].len, buffer[0][0].len]
+	dtype := hdftype(buffer[0][0][0])
+	// must flatten<T> else V cannot guess correctly
+	mut errc := C.H5LTmake_dataset(f.filedesc, dset_name, rank, unsafe { dims.data },
+		dtype, unsafe { flatten[T](flatten(buffer)).data })
+	return errc
+}
+
+// write_attribute1d adds a named 1-d numeric array (vector) attribute to a named HDF5 dataset.
+pub fn (f &HDF_File) write_attribute1d[T](dset_name &char, attr_name &char, buffer []T) ?HDF5_herr_t {
+	$if T is f64 {
+		return C.H5LTset_attribute_double(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is f32 {
+		return C.H5LTset_attribute_float(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is i64 {
+		return C.H5LTset_attribute_long_long(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is int {
+		return C.H5LTset_attribute_int(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is i16 {
+		return C.H5LTset_attribute_short(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is i8 {
+		return C.H5LTset_attribute_char(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is u64 {
+		return C.H5LTset_attribute_ulong(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is u32 {
+		return C.H5LTset_attribute_uint(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is u16 {
+		return C.H5LTset_attribute_ushort(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else $if T is u8 {
+		return C.H5LTset_attribute_uchar(f.filedesc, dset_name, attr_name, unsafe { buffer.data },
+			u64(buffer.len))
+	} $else {
+		return HDF5_herr_t(-1)
+	}
+}
+
+// write_attribute adds a named scalar attribute to a named HDF5 dataset.
+//   This is a helper function to avoid an array temporary; it writes a single element vector.
+//   It also supports writing a string attribute.
+pub fn (f &HDF_File) write_attribute[T](dset_name &char, attr_name &char, buffer T) ?HDF5_herr_t {
+	$if T is f64 {
+		return C.H5LTset_attribute_double(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is f32 {
+		return C.H5LTset_attribute_float(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is i64 {
+		return C.H5LTset_attribute_long_long(f.filedesc, dset_name, attr_name, &buffer,
+			u64(1))
+	} $else $if T is i32 {
+		return C.H5LTset_attribute_int(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is i16 {
+		return C.H5LTset_attribute_short(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is i8 {
+		return C.H5LTset_attribute_char(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is u64 {
+		return C.H5LTset_attribute_ulong(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is u32 {
+		return C.H5LTset_attribute_uint(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is u16 {
+		return C.H5LTset_attribute_ushort(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is u8 {
+		return C.H5LTset_attribute_uchar(f.filedesc, dset_name, attr_name, &buffer, u64(1))
+	} $else $if T is string {
+		return C.H5LTset_attribute_string(f.filedesc, dset_name, attr_name, &char(buffer.str))
+	} $else {
+		return HDF5_herr_t(-1)
+	}
+}
+
+// READERS
+
+// open_file opens an existing HDF5 file
+pub fn open_file(filename &char) ?HDF_File {
+	mut f := HDF_File{
+		filedesc: C.H5Fopen(unsafe { filename }, C.H5F_ACC_RDONLY, C.H5P_DEFAULT)
+	}
+	return f
+}
+
+// read_dataset1d reads a 1-d numeric array (vector) from a named HDF5 dataset in an HDF5 file.
+//   Replaces the value of the array.
+//   Maximum dimension is math.max_i32 or less (this is checked).
+pub fn (f &HDF_File) read_dataset1d[T](dset_name &char, mut dataset []T) {
+	mut rank := 0
+	mut class_id := HDF5_class_t(0)
+	mut type_size := HDF5_size_t(0)
+
+	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name, &rank)
+	assert errc >= 0
+	assert rank == 1
+
+	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
+	errc = C.H5LTget_dataset_info(f.filedesc, dset_name, unsafe { curdims.data }, &class_id,
+		&type_size)
+	assert errc >= 0
+	assert curdims[0] > 0
+	assert curdims[0] < math.max_i32
+
+	dtype := hdftype(dataset[0])
+	// note: V dims are int while hdf5 dims are u64
+	mut x := []T{len: int(curdims[0])}
+	errc = C.H5LTread_dataset(f.filedesc, dset_name, dtype, unsafe { x.data })
+	assert errc >= 0
+
+	unsafe {
+		dataset = x
+	}
+}
+
+// read_dataset2d reads a 2-d numeric array from a named HDF5 dataset in an HDF5 file.
+//   Replaces the value of the array.
+//   Maximum of any dimension is math.max_i32 or less (this is checked).
+//   Maximum total elements is also math.max_i32.
+pub fn (f &HDF_File) read_dataset2d[T](dset_name &char, mut dataset [][]T) {
+	adset := unsafe { tos5(dset_name) }
+	mut rank := 0
+	mut class_id := HDF5_class_t(0)
+	mut type_size := HDF5_size_t(0)
+
+	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name, &rank)
+	assert errc >= 0
+	assert rank == 2
+
+	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
+	errc = C.H5LTget_dataset_info(f.filedesc, dset_name, unsafe { curdims.data }, &class_id,
+		&type_size)
+	assert errc >= 0
+	assert curdims[0] > 0
+	assert curdims[1] > 0
+	assert curdims[0] < math.max_i32
+	assert curdims[1] < math.max_i32
+
+	dtype := hdftype(dataset[0][0])
+	mut y := make1type[T](int(curdims[0] * curdims[1]))
+
+	errc = C.H5LTread_dataset(f.filedesc, dset_name, dtype, unsafe { y.data })
+	assert errc >= 0
+
+	dataset = reshape(y, curdims) or {
+		println(' dataset ${adset} reshape failed')
+		return
+	}
+}
+
+// read_dataset3d reads a 3-d numeric array from a named HDF5 dataset in an HDF5 file.
+//   Replaces the value of the array with correctly dimensioned array.
+//   Maximum of any dimension is math.max_i32 or less (this is checked).
+//   Maximum total elements is also math.max_i32.
+pub fn (f &HDF_File) read_dataset3d[T](dset_name &char, mut dataset [][][]T) {
+	mut rank := 0
+	mut class_id := HDF5_class_t(0)
+	mut type_size := HDF5_size_t(0)
+	adset := unsafe { tos5(dset_name) }
+
+	mut errc := C.H5LTget_dataset_ndims(f.filedesc, dset_name, &rank)
+	assert errc >= 0
+	assert rank == 3
+
+	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
+	errc = C.H5LTget_dataset_info(f.filedesc, dset_name, unsafe { curdims.data }, &class_id,
+		&type_size)
+	assert errc >= 0
+	assert curdims[0] > 0
+	assert curdims[1] > 0
+	assert curdims[2] > 0
+	assert curdims[0] < math.max_i32
+	assert curdims[1] < math.max_i32
+	assert curdims[2] < math.max_i32
+
+	dtype := hdftype(dataset[0][0][0])
+	mut y := make1type[T](int(curdims[0] * curdims[1] * curdims[2]))
+
+	errc = C.H5LTread_dataset(f.filedesc, dset_name, dtype, unsafe { y.data })
+	assert errc >= 0
+
+	dataset = reshape3(y, curdims) or {
+		println(' dataset ${adset} reshape failed')
+		return
+	}
+}
+
+// reshape returns [][]x using []y and intended dimensions.
+// y.len() == product(dimensions) else error.
+fn reshape[T](y []T, dims []HDF5_hsize_t) ![][]T {
+	mut proddims := HDF5_hsize_t(1)
+	leny := HDF5_hsize_t(u64(y.len))
+	for i in 0 .. dims.len {
+		proddims = proddims * dims[i]
+	}
+	if leny != proddims {
+		return error(' reshape dimensions not equal to array length')
+	}
+	mut idims := []int{len: 2}
+	idims[0] = int(dims[0])
+	idims[1] = int(dims[1])
+
+	res := make2type[T](idims[0], 1)
+	unsafe {
+		for i in 0 .. idims[0] {
+			res[i].len = idims[1]
+			res[i].cap = idims[1]
+			res[i].data = &y[i * idims[1]]
+		}
+	}
+	return res
+}
+
+// reshape3 returns [][][]x using []y and intended dimensions.
+// y.len() == product(dimensions) else error.
+fn reshape3[T](y []T, dims []HDF5_hsize_t) ![][][]T {
+	mut proddims := HDF5_hsize_t(1)
+	leny := HDF5_hsize_t(u64(y.len))
+	for i in 0 .. dims.len {
+		proddims = proddims * dims[i]
+	}
+	if leny != proddims {
+		return error(' reshape3 dimensions not equal to array length')
+	}
+	mut idims := []int{len: 3}
+	idims[0] = int(dims[0])
+	idims[1] = int(dims[1])
+	idims[2] = int(dims[2])
+
+	res := make3type[T](idims[0], idims[1], 1)
+	unsafe {
+		for i in 0 .. idims[0] {
+			for k in 0 .. idims[1] {
+				res[i][k].len = idims[2]
+				res[i][k].cap = idims[2]
+				res[i][k].data = &y[i * idims[1] * idims[2] + k * idims[2]]
+			}
+		}
+	}
+	return res
+}
+
+// getattr_class_size reads back the HDF5 class (float, int, string) and size (1, 2, 4, 8) of a scalar attribute.
+// This is a helper function for read_attribute<T> for a scalar or read_attribute1d<T> for a vector.
+// Assumes the attribute and dataset exist.
+fn (f &HDF_File) getattr_class_size(dset_name &char, attr_name &char) (HDF5_class_t, HDF5_size_t) {
+	mut rank := int(0)
+	mut type_class := HDF5_class_t(0)
+	mut type_size := HDF5_size_t(0)
+
+	mut errc := C.H5LTget_attribute_ndims(f.filedesc, dset_name, attr_name, &rank)
+	assert errc >= 0
+	assert rank == 1
+
+	mut curdims := []HDF5_hsize_t{len: if rank == 1 { rank } else { 1 }, init: 0}
+	errc = C.H5LTget_attribute_info(f.filedesc, dset_name, attr_name, unsafe { curdims.data },
+		&type_class, &type_size)
+	assert errc >= 0
+	assert curdims[0] >= 1
+	return type_class, type_size
+}
+
+// checkdsetattr verifies dataset and attribute exist
+fn (f &HDF_File) checkdsetattr(dset_name &char, attr_name &char) bool {
+	mut dset_id := C.H5Dopen2(f.filedesc, dset_name, C.H5P_DEFAULT)
+	defer {
+		C.H5Dclose(dset_id)
+	}
+	if dset_id < 0 {
+		return false
+	}
+
+	errc := C.H5LTfind_attribute(dset_id, attr_name)
+	if errc == 0 {
+		return false
+	} else {
+		return true
+	}
+}
+
+// checktype verifies name, class and type-size for an attribute.
+// Returns true only if the name exists and class and type-size match.
+fn (f &HDF_File) checktype(dset_name &char, attr_name &char, type_class HDF5_class_t, type_size HDF5_size_t) bool {
+	mut x_type_class := HDF5_class_t(0)
+	mut x_type_size := HDF5_size_t(0)
+
+	mut dset_id := C.H5Dopen2(f.filedesc, dset_name, C.H5P_DEFAULT)
+	defer {
+		C.H5Dclose(dset_id)
+	}
+
+	errc := C.H5LTfind_attribute(dset_id, attr_name)
+
+	if errc == 0 {
+		return false
+	}
+
+	x_type_class, x_type_size = f.getattr_class_size(dset_name, attr_name)
+	if type_class == x_type_class && type_size == x_type_size {
+		return true
+	} else {
+		return false
+	}
+}
+
+// getstringattr gets a variable-length string attribute.
+// This is a helper function to check existance of and process string copies.
+// Strings are a special case since the length varies.
+// Assumes the dataset exists but does check the attribute exists.
+fn (f &HDF_File) getstringattr(dset_name &char, attr_name &char) !string {
+	mut type_class := HDF5_class_t(0)
+	mut type_size := HDF5_size_t(0)
+	mut curdims := HDF5_hsize_t(0)
+
+	adset := unsafe { tos5(dset_name) }
+	aattr := unsafe { tos5(attr_name) }
+	mut dset_id := C.H5Dopen2(f.filedesc, dset_name, C.H5P_DEFAULT)
+	defer {
+		C.H5Dclose(dset_id)
+	}
+
+	mut errc := C.H5LTfind_attribute(dset_id, attr_name)
+	if errc == 0 {
+		return error(' dataset ${adset} no attribute ${aattr}')
+	}
+
+	// we don't use our getattr_class_size() because strings have rank==0 and dims[0]==0
+	errc = C.H5LTget_attribute_info(f.filedesc, dset_name, attr_name, unsafe { &curdims },
+		&type_class, &type_size)
+	assert errc >= 0
+	assert type_class == C.H5T_STRING
+
+	if type_class == C.H5T_STRING {
+		mut buffer := vcalloc(type_size)
+		errc = C.H5LTget_attribute_string(f.filedesc, dset_name, attr_name, buffer)
+		assert errc >= 0
+		vs := unsafe { cstring_to_vstring(buffer) }
+		unsafe {
+			return vs
+		}
+	} else {
+		return error(' dataset ${adset} attribute ${aattr} not a string')
+	}
+}
+
+// readattribute gets a named scalar attribute from a named HDF5 dataset.
+//   This is a helper function to avoid an array temporary; it gets a single element vector.
+//   It also supports reading a string attribute.
+pub fn (f &HDF_File) read_attribute[T](dset_name &char, attr_name &char, mut attr_value T) ?bool {
+	mut errc := HDF5_herr_t(0)
+
+	if !f.checkdsetattr(dset_name, attr_name) {
+		return false
+	}
+
+	$if T is f64 {
+		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 8) {
+			errc = C.H5LTget_attribute_double(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is f32 {
+		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 4) {
+			errc = C.H5LTget_attribute_float(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i64 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
+			errc = C.H5LTget_attribute_long(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i32 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
+			errc = C.H5LTget_attribute_int(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i16 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
+			errc = C.H5LTget_attribute_short(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i8 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
+			errc = C.H5LTget_attribute_char(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u64 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
+			errc = C.H5LTget_attribute_ulong(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u32 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
+			errc = C.H5LTget_attribute_uint(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u16 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
+			errc = C.H5LTget_attribute_ushort(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u8 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
+			errc = C.H5LTget_attribute_uchar(f.filedesc, dset_name, attr_name, &attr_value)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is string {
+		attr_value = f.getstringattr(dset_name, attr_name) or {
+			attr_value = 'not available'
+			return false
+		}
+		return true
+	} $else {
+		eprintln('hdf5 getattr unsupported type: ${typeof(attr_value).name}')
+		return false
+	}
+}
+
+// read_attribute1d reads a 1-d numeric array (vector) from a named HDF5 dataset and named attribute in an HDF5 file.
+//   Replaces the value of the given array.
+//   Maximum dimension is math.max_i32 or less (this is checked).
+pub fn (f &HDF_File) read_attribute1d[T](dset_name &char, attr_name &char, mut attr_value []T) ?bool {
+	mut rank := 0
+	mut class_id := HDF5_class_t(0)
+	mut type_size := HDF5_size_t(0)
+
+	if !f.checkdsetattr(dset_name, attr_name) {
+		return false
+	}
+
+	mut errc := C.H5LTget_attribute_ndims(f.filedesc, dset_name, attr_name, &rank)
+	assert errc >= 0
+	assert rank == 1
+
+	mut curdims := []HDF5_hsize_t{len: rank, init: 0}
+	errc = C.H5LTget_attribute_info(f.filedesc, dset_name, attr_name, unsafe { curdims.data },
+		&class_id, &type_size)
+	assert errc >= 0
+	assert curdims[0] > 0
+	assert curdims[0] <= math.max_i32
+	if curdims[0] > math.max_i32 {
+		return false
+	}
+
+	// note: V dims are int while hdf5 dims are u64
+	mut x := []T{len: int(curdims[0])}
+	unsafe {
+		attr_value = x
+	}
+
+	$if T is f64 {
+		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 8) {
+			errc = C.H5LTget_attribute_double(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is f32 {
+		if f.checktype(dset_name, attr_name, C.H5T_FLOAT, 4) {
+			errc = C.H5LTget_attribute_float(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i64 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
+			errc = C.H5LTget_attribute_long(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i32 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
+			errc = C.H5LTget_attribute_int(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i16 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
+			errc = C.H5LTget_attribute_short(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is i8 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
+			errc = C.H5LTget_attribute_char(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u64 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 8) {
+			errc = C.H5LTget_attribute_ulong(f.filedesc, dset_name, attr_name, attr_value.data)
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u32 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 4) {
+			errc = C.H5LTget_attribute_uint(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u16 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 2) {
+			errc = C.H5LTget_attribute_ushort(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is u8 {
+		if f.checktype(dset_name, attr_name, C.H5T_INTEGER, 1) {
+			errc = C.H5LTget_attribute_uchar(f.filedesc, dset_name, attr_name, unsafe { attr_value.data })
+			assert errc >= 0
+			return true
+		}
+		return false
+	} $else $if T is string {
+		attr_value = f.getstringattr(dset_name, attr_name) or {
+			attr_value = 'not available'
+			return false
+		}
+		return true
+	} $else {
+		eprintln('hdf5 getattr unsupported type: ${typeof(attr_value).name}')
+		return false
+	}
+}
+
+// close releases memory resources for HDF5 files.
+pub fn (f &HDF_File) close() {
+	C.H5Fclose(f.filedesc)
+}

--- a/hdf5/readhdf5_test.v
+++ b/hdf5/readhdf5_test.v
@@ -1,32 +1,33 @@
+module hdf5
+
 import os
-import hdf5
 
 const (
 	h5dump     = 'h5dump'
 	h5data     = 'hdf_test.h5'
-	testfolder = os.join_path(os.vtmp_dir(),'vsl','readhdf5')
+	testfolder = os.join_path(os.vtmp_dir(), 'vsl', 'readhdf5')
 	testfile   = os.join_path(testfolder, h5data)
 	shortarray = []i32{len: 2}
 )
 
 fn testsuite_begin() {
-	os.rmdir_all(testfolder) or {}
-	os.mkdir_all(testfolder)!
+	os.rmdir_all(hdf5.testfolder) or {}
+	os.mkdir_all(hdf5.testfolder)!
 
-	assert os.exists_in_system_path(h5dump)
+	assert os.exists_in_system_path(hdf5.h5dump)
 
-	f := hdf5.new_file(testfile.str)?
-	f.write_dataset1d(c'Shortarray', shortarray)?
+	f := new_file(hdf5.testfile)?
+	f.write_dataset1d('Shortarray', hdf5.shortarray)?
 	f.close()
 }
 
 fn testsuite_end() {
-	os.rmdir_all(testfolder) or {}
+	os.rmdir_all(hdf5.testfolder) or {}
 }
 
 // verify simple operation of one datatype (int)
 fn test_run() {
-	res := os.execute('h5dump ${testfile}')
+	res := os.execute('h5dump ${hdf5.testfile}')
 	output := res.output.trim_space()
 	assert output.contains('tsession')
 	assert output.contains('Shortarray')

--- a/hdf5/readhdf5_test.v
+++ b/hdf5/readhdf5_test.v
@@ -1,0 +1,36 @@
+import os
+import hdf5
+
+const (
+	h5dump     = 'h5dump'
+	h5data     = 'hdf_test.h5'
+	testfolder = os.join_path(os.vtmp_dir(),'vsl','readhdf5')
+	testfile   = os.join_path(testfolder, h5data)
+	shortarray = []i32{len: 2}
+)
+
+fn testsuite_begin() {
+	os.rmdir_all(testfolder) or {}
+	os.mkdir_all(testfolder)!
+
+	assert os.exists_in_system_path(h5dump)
+
+	f := hdf5.new_file(testfile.str)?
+	f.write_dataset1d(c'Shortarray', shortarray)?
+	f.close()
+}
+
+fn testsuite_end() {
+	os.rmdir_all(testfolder) or {}
+}
+
+// verify simple operation of one datatype (int)
+fn test_run() {
+	res := os.execute('h5dump ${testfile}')
+	output := res.output.trim_space()
+	assert output.contains('tsession')
+	assert output.contains('Shortarray')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+	assert output.contains('DATA {')
+	assert output.contains('(0): 0, 0')
+}

--- a/hdf5/three_d_test.v
+++ b/hdf5/three_d_test.v
@@ -1,0 +1,239 @@
+import os
+import hdf5
+
+fn make1type[T](a int) []T {
+	return []T{len: a, init: T(it)}
+}
+
+fn make2type[T](a int, b int) [][]T {
+	return [][]T{len: a, init: []T{len: b}}
+}
+
+fn make3type[T](a int, b int, c int) [][][]T {
+	return [][][]T{len: a, init: make2type[T](b, c)}
+}
+
+fn compare1d[T](ax []T, bx []T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		assert ax[i] == bx[i]
+	}
+}
+
+fn compare2d[T](ax [][]T, bx [][]T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		compare1d(ax[i], bx[i])
+	}
+}
+
+fn compare3d[T](ax [][][]T, bx [][][]T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		compare2d(ax[i], bx[i])
+	}
+}
+
+fn check2dims[T](ax [][]T, b int, c int) {
+	assert ax.len == b
+	for i in 0 .. ax.len {
+		assert ax[i].len == c
+	}
+}
+
+fn check3dims[T](ax [][][]T, b int, c int, d int) {
+	assert ax.len == b
+	for i in 0 .. ax.len {
+		assert ax[i].len == c
+		for j in 0 .. ax[i].len {
+			assert ax[i][j].len == d
+		}
+	}
+}
+
+const (
+	h5dump     = 'h5dump'
+	h5data     = 'hdf_three.h5'
+	testfolder = os.join_path(os.vtmp_dir(), 'vsl', 'three_d_test')
+	testfile   = os.join_path(testfolder, h5data)
+)
+
+fn test_3d() {
+	mut i8array := make3type[i8](3, 4, 5)
+	mut u8array := make3type[u8](3, 4, 5)
+
+	mut i16array := make3type[i16](3, 4, 5)
+	mut u16array := make3type[u16](3, 4, 5)
+
+	mut i32array := make3type[i32](3, 4, 5)
+	mut u32array := make3type[u32](3, 4, 5)
+
+	mut i64array := make3type[i64](3, 4, 5)
+	mut u64array := make3type[u64](3, 4, 5)
+
+	mut f32array := make3type[f32](3, 4, 5)
+	mut f64array := make3type[f64](3, 4, 5)
+
+	mut intarray := make3type[int](3, 4, 5)
+
+	for i in 0 .. 3 {
+		for j in 0 .. 4 {
+			for k in 0 .. 5 {
+				i8array[i][j][k] = -i * 30 - 2 * j - k
+				u8array[i][j][k] = i * 30 + 2 * j + k + 1
+				i16array[i][j][k] = -i * 100 + 10 * j + k
+				u16array[i][j][k] = i * 100 + 10 * j + k
+				i32array[i][j][k] = -i * 1000 - 10 * j - k
+				u32array[i][j][k] = i * 1000 + 10 * j + k
+				i64array[i][j][k] = -i * 10000 - 10 * j - k
+				u64array[i][j][k] = i * 10000 + 10 * j + k
+				intarray[i][j][k] = i * 20000 + 10 * j + k
+				f32array[i][j][k] = i * 20.00 + 10 * j + k
+				f64array[i][j][k] = i * 200.0 + 10 * j + k
+			}
+		}
+	}
+
+	f := hdf5.new_file(testfile.str)?
+
+	f.write_dataset3d(c'i8array', i8array)?
+	f.write_dataset3d(c'u8array', u8array)?
+
+	f.write_dataset3d(c'i16array', i16array)?
+	f.write_dataset3d(c'u16array', u16array)?
+
+	f.write_dataset3d(c'i32array', i32array)?
+	f.write_dataset3d(c'u32array', u32array)?
+
+	f.write_dataset3d(c'i64array', i64array)?
+	f.write_dataset3d(c'u64array', u64array)?
+
+	f.write_dataset3d(c'intarray', intarray)?
+
+	f.write_dataset3d(c'f32array', f32array)?
+	f.write_dataset3d(c'f64array', f64array)?
+
+	f.close()
+}
+
+fn testsuite_begin() {
+	os.rmdir_all(testfolder) or {}
+	os.mkdir_all(testfolder)!
+
+	assert os.exists_in_system_path(h5dump)
+
+	test_3d()
+}
+
+fn testsuite_end() {
+	//        os.rmdir_all(testfolder) or {}
+}
+
+// verify all datatypes in 3 dimensions
+fn test_run() {
+	res := os.execute('h5dump ${testfile}')
+	output := res.output.trim_space()
+	assert output.contains('i8array')
+	assert output.contains('u8array')
+	assert output.contains('DATATYPE  H5T_STD_I8LE')
+	assert output.contains('DATATYPE  H5T_STD_U8LE')
+
+	assert output.contains('i16array')
+	assert output.contains('u16array')
+	assert output.contains('DATATYPE  H5T_STD_I16LE')
+	assert output.contains('DATATYPE  H5T_STD_U16LE')
+
+	assert output.contains('i32array')
+	assert output.contains('u32array')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+	assert output.contains('DATATYPE  H5T_STD_U32LE')
+
+	assert output.contains('i64array')
+	assert output.contains('u64array')
+	assert output.contains('DATATYPE  H5T_STD_I64LE')
+	assert output.contains('DATATYPE  H5T_STD_U64LE')
+
+	assert output.contains('f32array')
+	assert output.contains('f64array')
+	assert output.contains('DATATYPE  H5T_IEEE_F32LE')
+	assert output.contains('DATATYPE  H5T_IEEE_F64LE')
+
+	assert output.contains('intarray')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+
+	assert 2 == output.count('H5T_STD_I32LE') // i32 and int
+
+	readback()?
+	readback()? // worth doing twice
+}
+
+fn readback() ? {
+	// read_dataset3d will change the mut array size
+
+	mut i8arrayrd := make3type[i8](1, 1, 1)
+	mut u8arrayrd := make3type[u8](1, 1, 1)
+
+	mut i16arrayrd := make3type[i16](1, 1, 1)
+	mut u16arrayrd := make3type[u16](1, 1, 1)
+
+	mut i32arrayrd := make3type[i32](1, 1, 1)
+	mut u32arrayrd := make3type[u32](1, 1, 1)
+
+	mut i64arrayrd := make3type[i64](1, 1, 1)
+	mut u64arrayrd := make3type[u64](1, 1, 1)
+
+	mut f32arrayrd := make3type[f32](1, 1, 1)
+	mut f64arrayrd := make3type[f64](1, 1, 1)
+
+	mut intarrayrd := make3type[int](1, 1, 1)
+
+	f := hdf5.open_file(testfile.str)?
+
+	f.read_dataset3d(c'i8array', mut i8arrayrd)
+	f.read_dataset3d(c'u8array', mut u8arrayrd)
+	check3dims(i8arrayrd, 3, 4, 5)
+	check3dims(u8arrayrd, 3, 4, 5)
+
+	f.read_dataset3d(c'i16array', mut i16arrayrd)
+	f.read_dataset3d(c'u16array', mut u16arrayrd)
+	check3dims(i16arrayrd, 3, 4, 5)
+	check3dims(u16arrayrd, 3, 4, 5)
+
+	f.read_dataset3d(c'i32array', mut i32arrayrd)
+	f.read_dataset3d(c'u32array', mut u32arrayrd)
+	check3dims(i32arrayrd, 3, 4, 5)
+	check3dims(u32arrayrd, 3, 4, 5)
+
+	f.read_dataset3d(c'i64array', mut i64arrayrd)
+	f.read_dataset3d(c'u64array', mut u64arrayrd)
+	check3dims(i64arrayrd, 3, 4, 5)
+	check3dims(u64arrayrd, 3, 4, 5)
+
+	f.read_dataset3d(c'f32array', mut f32arrayrd)
+	f.read_dataset3d(c'f64array', mut f64arrayrd)
+	check3dims(f32arrayrd, 3, 4, 5)
+	check3dims(f64arrayrd, 3, 4, 5)
+
+	f.read_dataset3d(c'intarray', mut intarrayrd)
+	check3dims(intarrayrd, 3, 4, 5)
+
+	for i in 0 .. 3 {
+		for j in 0 .. 4 {
+			for k in 0 .. 5 {
+				assert i8arrayrd[i][j][k] == -i * 30 - 2 * j - k
+				assert u8arrayrd[i][j][k] == i * 30 + 2 * j + k + 1
+				assert i16arrayrd[i][j][k] == -i * 100 + 10 * j + k
+				assert u16arrayrd[i][j][k] == i * 100 + 10 * j + k
+				assert i32arrayrd[i][j][k] == -i * 1000 - 10 * j - k
+				assert u32arrayrd[i][j][k] == i * 1000 + 10 * j + k
+				assert i64arrayrd[i][j][k] == -i * 10000 - 10 * j - k
+				assert u64arrayrd[i][j][k] == i * 10000 + 10 * j + k
+				assert intarrayrd[i][j][k] == i * 20000 + 10 * j + k
+				assert f32arrayrd[i][j][k] == i * 20.00 + 10 * j + k
+				assert f64arrayrd[i][j][k] == i * 200.0 + 10 * j + k
+			}
+		}
+	}
+
+	f.close()
+}

--- a/hdf5/three_d_test.v
+++ b/hdf5/three_d_test.v
@@ -1,55 +1,6 @@
+module hdf5
+
 import os
-import hdf5
-
-fn make1type[T](a int) []T {
-	return []T{len: a, init: T(it)}
-}
-
-fn make2type[T](a int, b int) [][]T {
-	return [][]T{len: a, init: []T{len: b}}
-}
-
-fn make3type[T](a int, b int, c int) [][][]T {
-	return [][][]T{len: a, init: make2type[T](b, c)}
-}
-
-fn compare1d[T](ax []T, bx []T) {
-	assert ax.len == bx.len
-	for i in 0 .. ax.len {
-		assert ax[i] == bx[i]
-	}
-}
-
-fn compare2d[T](ax [][]T, bx [][]T) {
-	assert ax.len == bx.len
-	for i in 0 .. ax.len {
-		compare1d(ax[i], bx[i])
-	}
-}
-
-fn compare3d[T](ax [][][]T, bx [][][]T) {
-	assert ax.len == bx.len
-	for i in 0 .. ax.len {
-		compare2d(ax[i], bx[i])
-	}
-}
-
-fn check2dims[T](ax [][]T, b int, c int) {
-	assert ax.len == b
-	for i in 0 .. ax.len {
-		assert ax[i].len == c
-	}
-}
-
-fn check3dims[T](ax [][][]T, b int, c int, d int) {
-	assert ax.len == b
-	for i in 0 .. ax.len {
-		assert ax[i].len == c
-		for j in 0 .. ax[i].len {
-			assert ax[i][j].len == d
-		}
-	}
-}
 
 const (
 	h5dump     = 'h5dump'
@@ -94,33 +45,33 @@ fn test_3d() {
 		}
 	}
 
-	f := hdf5.new_file(testfile.str)?
+	f := new_file(hdf5.testfile)?
 
-	f.write_dataset3d(c'i8array', i8array)?
-	f.write_dataset3d(c'u8array', u8array)?
+	f.write_dataset3d('i8array', i8array)?
+	f.write_dataset3d('u8array', u8array)?
 
-	f.write_dataset3d(c'i16array', i16array)?
-	f.write_dataset3d(c'u16array', u16array)?
+	f.write_dataset3d('i16array', i16array)?
+	f.write_dataset3d('u16array', u16array)?
 
-	f.write_dataset3d(c'i32array', i32array)?
-	f.write_dataset3d(c'u32array', u32array)?
+	f.write_dataset3d('i32array', i32array)?
+	f.write_dataset3d('u32array', u32array)?
 
-	f.write_dataset3d(c'i64array', i64array)?
-	f.write_dataset3d(c'u64array', u64array)?
+	f.write_dataset3d('i64array', i64array)?
+	f.write_dataset3d('u64array', u64array)?
 
-	f.write_dataset3d(c'intarray', intarray)?
+	f.write_dataset3d('intarray', intarray)?
 
-	f.write_dataset3d(c'f32array', f32array)?
-	f.write_dataset3d(c'f64array', f64array)?
+	f.write_dataset3d('f32array', f32array)?
+	f.write_dataset3d('f64array', f64array)?
 
 	f.close()
 }
 
 fn testsuite_begin() {
-	os.rmdir_all(testfolder) or {}
-	os.mkdir_all(testfolder)!
+	os.rmdir_all(hdf5.testfolder) or {}
+	os.mkdir_all(hdf5.testfolder)!
 
-	assert os.exists_in_system_path(h5dump)
+	assert os.exists_in_system_path(hdf5.h5dump)
 
 	test_3d()
 }
@@ -131,7 +82,7 @@ fn testsuite_end() {
 
 // verify all datatypes in 3 dimensions
 fn test_run() {
-	res := os.execute('h5dump ${testfile}')
+	res := os.execute('h5dump ${hdf5.testfile}')
 	output := res.output.trim_space()
 	assert output.contains('i8array')
 	assert output.contains('u8array')
@@ -187,34 +138,34 @@ fn readback() ? {
 
 	mut intarrayrd := make3type[int](1, 1, 1)
 
-	f := hdf5.open_file(testfile.str)?
+	f := open_file(hdf5.testfile)?
 
-	f.read_dataset3d(c'i8array', mut i8arrayrd)
-	f.read_dataset3d(c'u8array', mut u8arrayrd)
+	f.read_dataset3d('i8array', mut i8arrayrd)
+	f.read_dataset3d('u8array', mut u8arrayrd)
 	check3dims(i8arrayrd, 3, 4, 5)
 	check3dims(u8arrayrd, 3, 4, 5)
 
-	f.read_dataset3d(c'i16array', mut i16arrayrd)
-	f.read_dataset3d(c'u16array', mut u16arrayrd)
+	f.read_dataset3d('i16array', mut i16arrayrd)
+	f.read_dataset3d('u16array', mut u16arrayrd)
 	check3dims(i16arrayrd, 3, 4, 5)
 	check3dims(u16arrayrd, 3, 4, 5)
 
-	f.read_dataset3d(c'i32array', mut i32arrayrd)
-	f.read_dataset3d(c'u32array', mut u32arrayrd)
+	f.read_dataset3d('i32array', mut i32arrayrd)
+	f.read_dataset3d('u32array', mut u32arrayrd)
 	check3dims(i32arrayrd, 3, 4, 5)
 	check3dims(u32arrayrd, 3, 4, 5)
 
-	f.read_dataset3d(c'i64array', mut i64arrayrd)
-	f.read_dataset3d(c'u64array', mut u64arrayrd)
+	f.read_dataset3d('i64array', mut i64arrayrd)
+	f.read_dataset3d('u64array', mut u64arrayrd)
 	check3dims(i64arrayrd, 3, 4, 5)
 	check3dims(u64arrayrd, 3, 4, 5)
 
-	f.read_dataset3d(c'f32array', mut f32arrayrd)
-	f.read_dataset3d(c'f64array', mut f64arrayrd)
+	f.read_dataset3d('f32array', mut f32arrayrd)
+	f.read_dataset3d('f64array', mut f64arrayrd)
 	check3dims(f32arrayrd, 3, 4, 5)
 	check3dims(f64arrayrd, 3, 4, 5)
 
-	f.read_dataset3d(c'intarray', mut intarrayrd)
+	f.read_dataset3d('intarray', mut intarrayrd)
 	check3dims(intarrayrd, 3, 4, 5)
 
 	for i in 0 .. 3 {

--- a/hdf5/two_d_test.v
+++ b/hdf5/two_d_test.v
@@ -1,0 +1,218 @@
+import os
+import hdf5
+
+fn make1type[T](a int) []T {
+	return []T{len: a, init: T(it)}
+}
+
+fn make2type[T](a int, b int) [][]T {
+	return [][]T{len: a, init: []T{len: b}}
+}
+
+fn make3type[T](a int, b int, c int) [][][]T {
+	return [][][]T{len: a, init: make2type[T](b, c)}
+}
+
+fn compare1d[T](ax []T, bx []T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		assert ax[i] == bx[i]
+	}
+}
+
+fn compare2d[T](ax [][]T, bx [][]T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		compare1d(ax[i], bx[i])
+	}
+}
+
+fn check2dims[T](ax [][]T, b int) {
+	assert ax.len == b
+	for i in 0 .. ax.len {
+		assert ax[i].len == b
+	}
+}
+
+const (
+	h5dump     = 'h5dump'
+	h5data     = 'hdf_two.h5'
+	testfolder = os.join_path(os.vtmp_dir(),'vsl','two_d_test')
+	testfile   = os.join_path(testfolder, h5data)
+)
+
+fn test_2d() {
+	mut i8array := make2type[i8](3, 3)
+	mut u8array := make2type[u8](3, 3)
+
+	mut i16array := make2type[i16](3, 3)
+	mut u16array := make2type[u16](3, 3)
+
+	mut i32array := make2type[i32](3, 3)
+	mut u32array := make2type[u32](3, 3)
+
+	mut i64array := make2type[i64](3, 3)
+	mut u64array := make2type[u64](3, 3)
+
+	mut f32array := make2type[f32](3, 3)
+	mut f64array := make2type[f64](3, 3)
+
+	mut intarray := make2type[int](3, 3)
+
+	for i in 0 .. 3 {
+		for j in 0 .. 3 {
+			i8array[i][j] = -i * 10 - j
+			u8array[i][j] = i * 10 + j
+			i16array[i][j] = -i * 100 + j
+			u16array[i][j] = i * 100 + j
+			i32array[i][j] = -i * 1000 + j
+			u32array[i][j] = i * 1000 + j
+			i64array[i][j] = -i * 10000 + j
+			u64array[i][j] = i * 10000 + j
+			intarray[i][j] = i * 20000 + j
+			f32array[i][j] = i * 20.00 + j
+			f64array[i][j] = i * 200.0 + j
+		}
+	}
+
+	f := hdf5.new_file(testfile.str)?
+
+	f.write_dataset2d(c'i8array', i8array)?
+	f.write_dataset2d(c'u8array', u8array)?
+
+	f.write_dataset2d(c'i16array', i16array)?
+	f.write_dataset2d(c'u16array', u16array)?
+
+	f.write_dataset2d(c'i32array', i32array)?
+	f.write_dataset2d(c'u32array', u32array)?
+
+	f.write_dataset2d(c'i64array', i64array)?
+	f.write_dataset2d(c'u64array', u64array)?
+
+	f.write_dataset2d(c'intarray', intarray)?
+
+	f.write_dataset2d(c'f32array', f32array)?
+	f.write_dataset2d(c'f64array', f64array)?
+
+	f.close()
+}
+
+fn testsuite_begin() {
+	os.rmdir_all(testfolder) or {}
+	os.mkdir_all(testfolder)!
+
+	assert os.exists_in_system_path(h5dump)
+
+	test_2d()
+}
+
+fn testsuite_end() {
+	os.rmdir_all(testfolder) or {}
+}
+
+// verify all datatypes in 2 dimensions
+fn test_run() {
+	res := os.execute('h5dump ${testfile}')
+	output := res.output.trim_space()
+	assert output.contains('i8array')
+	assert output.contains('u8array')
+	assert output.contains('DATATYPE  H5T_STD_I8LE')
+	assert output.contains('DATATYPE  H5T_STD_U8LE')
+
+	assert output.contains('i16array')
+	assert output.contains('u16array')
+	assert output.contains('DATATYPE  H5T_STD_I16LE')
+	assert output.contains('DATATYPE  H5T_STD_U16LE')
+
+	assert output.contains('i32array')
+	assert output.contains('u32array')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+	assert output.contains('DATATYPE  H5T_STD_U32LE')
+
+	assert output.contains('i64array')
+	assert output.contains('u64array')
+	assert output.contains('DATATYPE  H5T_STD_I64LE')
+	assert output.contains('DATATYPE  H5T_STD_U64LE')
+
+	assert output.contains('f32array')
+	assert output.contains('f64array')
+	assert output.contains('DATATYPE  H5T_IEEE_F32LE')
+	assert output.contains('DATATYPE  H5T_IEEE_F64LE')
+
+	assert output.contains('intarray')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+
+	assert 2 == output.count('H5T_STD_I32LE') // i32 and int
+
+	readback()?
+	readback()? // worth doing twice
+}
+
+fn readback() ? {
+	// read_dataset2d will change the mut array size
+
+	mut i8arrayrd := make2type[i8](1, 1)
+	mut u8arrayrd := make2type[u8](1, 1)
+
+	mut i16arrayrd := make2type[i16](1, 1)
+	mut u16arrayrd := make2type[u16](1, 1)
+
+	mut i32arrayrd := make2type[i32](1, 1)
+	mut u32arrayrd := make2type[u32](1, 1)
+
+	mut i64arrayrd := make2type[i64](1, 1)
+	mut u64arrayrd := make2type[u64](1, 1)
+
+	mut f32arrayrd := make2type[f32](1, 1)
+	mut f64arrayrd := make2type[f64](1, 1)
+
+	mut intarrayrd := make2type[int](1, 1)
+
+	f := hdf5.open_file(testfile.str)?
+
+	f.read_dataset2d(c'i8array', mut i8arrayrd)
+	f.read_dataset2d(c'u8array', mut u8arrayrd)
+	check2dims(i8arrayrd, 3)
+	check2dims(u8arrayrd, 3)
+
+	f.read_dataset2d(c'i16array', mut i16arrayrd)
+	f.read_dataset2d(c'u16array', mut u16arrayrd)
+	check2dims(i16arrayrd, 3)
+	check2dims(u16arrayrd, 3)
+
+	f.read_dataset2d(c'i32array', mut i32arrayrd)
+	f.read_dataset2d(c'u32array', mut u32arrayrd)
+	check2dims(i32arrayrd, 3)
+	check2dims(u32arrayrd, 3)
+
+	f.read_dataset2d(c'i64array', mut i64arrayrd)
+	f.read_dataset2d(c'u64array', mut u64arrayrd)
+	check2dims(i64arrayrd, 3)
+	check2dims(u64arrayrd, 3)
+
+	f.read_dataset2d(c'f32array', mut f32arrayrd)
+	f.read_dataset2d(c'f64array', mut f64arrayrd)
+	check2dims(f32arrayrd, 3)
+	check2dims(f64arrayrd, 3)
+
+	f.read_dataset2d(c'intarray', mut intarrayrd)
+	check2dims(intarrayrd, 3)
+
+	for i in 0 .. 3 {
+		for j in 0 .. 3 {
+			assert i8arrayrd[i][j] == -i * 10 - j
+			assert u8arrayrd[i][j] == i * 10 + j
+			assert i16arrayrd[i][j] == -i * 100 + j
+			assert u16arrayrd[i][j] == i * 100 + j
+			assert i32arrayrd[i][j] == -i * 1000 + j
+			assert u32arrayrd[i][j] == i * 1000 + j
+			assert i64arrayrd[i][j] == -i * 10000 + j
+			assert u64arrayrd[i][j] == i * 10000 + j
+			assert intarrayrd[i][j] == i * 20000 + j
+			assert f32arrayrd[i][j] == i * 20.00 + j
+			assert f64arrayrd[i][j] == i * 200.0 + j
+		}
+	}
+
+	f.close()
+}

--- a/hdf5/two_d_test.v
+++ b/hdf5/two_d_test.v
@@ -1,43 +1,11 @@
+module hdf5
+
 import os
-import hdf5
-
-fn make1type[T](a int) []T {
-	return []T{len: a, init: T(it)}
-}
-
-fn make2type[T](a int, b int) [][]T {
-	return [][]T{len: a, init: []T{len: b}}
-}
-
-fn make3type[T](a int, b int, c int) [][][]T {
-	return [][][]T{len: a, init: make2type[T](b, c)}
-}
-
-fn compare1d[T](ax []T, bx []T) {
-	assert ax.len == bx.len
-	for i in 0 .. ax.len {
-		assert ax[i] == bx[i]
-	}
-}
-
-fn compare2d[T](ax [][]T, bx [][]T) {
-	assert ax.len == bx.len
-	for i in 0 .. ax.len {
-		compare1d(ax[i], bx[i])
-	}
-}
-
-fn check2dims[T](ax [][]T, b int) {
-	assert ax.len == b
-	for i in 0 .. ax.len {
-		assert ax[i].len == b
-	}
-}
 
 const (
 	h5dump     = 'h5dump'
 	h5data     = 'hdf_two.h5'
-	testfolder = os.join_path(os.vtmp_dir(),'vsl','two_d_test')
+	testfolder = os.join_path(os.vtmp_dir(), 'vsl', 'two_d_test')
 	testfile   = os.join_path(testfolder, h5data)
 )
 
@@ -75,44 +43,44 @@ fn test_2d() {
 		}
 	}
 
-	f := hdf5.new_file(testfile.str)?
+	f := new_file(hdf5.testfile)?
 
-	f.write_dataset2d(c'i8array', i8array)?
-	f.write_dataset2d(c'u8array', u8array)?
+	f.write_dataset2d('i8array', i8array)?
+	f.write_dataset2d('u8array', u8array)?
 
-	f.write_dataset2d(c'i16array', i16array)?
-	f.write_dataset2d(c'u16array', u16array)?
+	f.write_dataset2d('i16array', i16array)?
+	f.write_dataset2d('u16array', u16array)?
 
-	f.write_dataset2d(c'i32array', i32array)?
-	f.write_dataset2d(c'u32array', u32array)?
+	f.write_dataset2d('i32array', i32array)?
+	f.write_dataset2d('u32array', u32array)?
 
-	f.write_dataset2d(c'i64array', i64array)?
-	f.write_dataset2d(c'u64array', u64array)?
+	f.write_dataset2d('i64array', i64array)?
+	f.write_dataset2d('u64array', u64array)?
 
-	f.write_dataset2d(c'intarray', intarray)?
+	f.write_dataset2d('intarray', intarray)?
 
-	f.write_dataset2d(c'f32array', f32array)?
-	f.write_dataset2d(c'f64array', f64array)?
+	f.write_dataset2d('f32array', f32array)?
+	f.write_dataset2d('f64array', f64array)?
 
 	f.close()
 }
 
 fn testsuite_begin() {
-	os.rmdir_all(testfolder) or {}
-	os.mkdir_all(testfolder)!
+	os.rmdir_all(hdf5.testfolder) or {}
+	os.mkdir_all(hdf5.testfolder)!
 
-	assert os.exists_in_system_path(h5dump)
+	assert os.exists_in_system_path(hdf5.h5dump)
 
 	test_2d()
 }
 
 fn testsuite_end() {
-	os.rmdir_all(testfolder) or {}
+	os.rmdir_all(hdf5.testfolder) or {}
 }
 
 // verify all datatypes in 2 dimensions
 fn test_run() {
-	res := os.execute('h5dump ${testfile}')
+	res := os.execute('h5dump ${hdf5.testfile}')
 	output := res.output.trim_space()
 	assert output.contains('i8array')
 	assert output.contains('u8array')
@@ -168,35 +136,35 @@ fn readback() ? {
 
 	mut intarrayrd := make2type[int](1, 1)
 
-	f := hdf5.open_file(testfile.str)?
+	f := open_file(hdf5.testfile)?
 
-	f.read_dataset2d(c'i8array', mut i8arrayrd)
-	f.read_dataset2d(c'u8array', mut u8arrayrd)
-	check2dims(i8arrayrd, 3)
-	check2dims(u8arrayrd, 3)
+	f.read_dataset2d('i8array', mut i8arrayrd)
+	f.read_dataset2d('u8array', mut u8arrayrd)
+	check2dims(i8arrayrd, 3, 3)
+	check2dims(u8arrayrd, 3, 3)
 
-	f.read_dataset2d(c'i16array', mut i16arrayrd)
-	f.read_dataset2d(c'u16array', mut u16arrayrd)
-	check2dims(i16arrayrd, 3)
-	check2dims(u16arrayrd, 3)
+	f.read_dataset2d('i16array', mut i16arrayrd)
+	f.read_dataset2d('u16array', mut u16arrayrd)
+	check2dims(i16arrayrd, 3, 3)
+	check2dims(u16arrayrd, 3, 3)
 
-	f.read_dataset2d(c'i32array', mut i32arrayrd)
-	f.read_dataset2d(c'u32array', mut u32arrayrd)
-	check2dims(i32arrayrd, 3)
-	check2dims(u32arrayrd, 3)
+	f.read_dataset2d('i32array', mut i32arrayrd)
+	f.read_dataset2d('u32array', mut u32arrayrd)
+	check2dims(i32arrayrd, 3, 3)
+	check2dims(u32arrayrd, 3, 3)
 
-	f.read_dataset2d(c'i64array', mut i64arrayrd)
-	f.read_dataset2d(c'u64array', mut u64arrayrd)
-	check2dims(i64arrayrd, 3)
-	check2dims(u64arrayrd, 3)
+	f.read_dataset2d('i64array', mut i64arrayrd)
+	f.read_dataset2d('u64array', mut u64arrayrd)
+	check2dims(i64arrayrd, 3, 3)
+	check2dims(u64arrayrd, 3, 3)
 
-	f.read_dataset2d(c'f32array', mut f32arrayrd)
-	f.read_dataset2d(c'f64array', mut f64arrayrd)
-	check2dims(f32arrayrd, 3)
-	check2dims(f64arrayrd, 3)
+	f.read_dataset2d('f32array', mut f32arrayrd)
+	f.read_dataset2d('f64array', mut f64arrayrd)
+	check2dims(f32arrayrd, 3, 3)
+	check2dims(f64arrayrd, 3, 3)
 
-	f.read_dataset2d(c'intarray', mut intarrayrd)
-	check2dims(intarrayrd, 3)
+	f.read_dataset2d('intarray', mut intarrayrd)
+	check2dims(intarrayrd, 3, 3)
 
 	for i in 0 .. 3 {
 		for j in 0 .. 3 {

--- a/hdf5/typeshdf5_test.v
+++ b/hdf5/typeshdf5_test.v
@@ -1,0 +1,163 @@
+import os
+import hdf5
+
+fn make1type[T](a int) []T {
+	return []T{len: a, init: T(it)}
+}
+
+fn compare1d[T](ax []T, bx []T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		assert ax[i] == bx[i]
+	}
+}
+
+const (
+	h5dump     = 'h5dump'
+	h5data     = 'hdf_types.h5'
+	testfolder = os.join_path(os.vtmp_dir(),'vsl','typeshdf5')
+	testfile   = os.join_path(testfolder, h5data)
+
+	i8array    = make1type[i8](2)
+	u8array    = make1type[u8](2)
+
+	i16array   = make1type[i16](2)
+	u16array   = make1type[u16](2)
+
+	i32array   = make1type[i32](2)
+	u32array   = make1type[u32](2)
+
+	i64array   = make1type[i64](2)
+	u64array   = make1type[u64](2)
+
+	f32array   = make1type[f32](2)
+	f64array   = make1type[f64](2)
+
+	intarray   = make1type[int](2)
+)
+
+fn testsuite_begin() {
+	os.rmdir_all(testfolder) or {}
+	os.mkdir_all(testfolder)!
+
+	assert os.exists_in_system_path(h5dump)
+
+	f := hdf5.new_file(testfile.str)?
+
+	f.write_dataset1d(c'i8array', i8array)?
+	f.write_dataset1d(c'u8array', u8array)?
+
+	f.write_dataset1d(c'i16array', i16array)?
+	f.write_dataset1d(c'u16array', u16array)?
+
+	f.write_dataset1d(c'i32array', i32array)?
+	f.write_dataset1d(c'u32array', u32array)?
+
+	f.write_dataset1d(c'i64array', i64array)?
+	f.write_dataset1d(c'u64array', u64array)?
+
+	f.write_dataset1d(c'intarray', intarray)?
+
+	f.write_dataset1d(c'f32array', f32array)?
+	f.write_dataset1d(c'f64array', f64array)?
+
+	f.close()
+}
+
+fn testsuite_end() {
+	//        os.rmdir_all(testfolder) or {}
+}
+
+// verify all datatypes in 1 dimension
+fn test_run() {
+	res := os.execute('h5dump ${testfile}')
+	output := res.output.trim_space()
+	assert output.contains('i8array')
+	assert output.contains('u8array')
+	assert output.contains('DATATYPE  H5T_STD_I8LE')
+	assert output.contains('DATATYPE  H5T_STD_U8LE')
+
+	assert output.contains('i16array')
+	assert output.contains('u16array')
+	assert output.contains('DATATYPE  H5T_STD_I16LE')
+	assert output.contains('DATATYPE  H5T_STD_U16LE')
+
+	assert output.contains('i32array')
+	assert output.contains('u32array')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+	assert output.contains('DATATYPE  H5T_STD_U32LE')
+
+	assert output.contains('i64array')
+	assert output.contains('u64array')
+	assert output.contains('DATATYPE  H5T_STD_I64LE')
+	assert output.contains('DATATYPE  H5T_STD_U64LE')
+
+	assert output.contains('f32array')
+	assert output.contains('f64array')
+	assert output.contains('DATATYPE  H5T_IEEE_F32LE')
+	assert output.contains('DATATYPE  H5T_IEEE_F64LE')
+
+	assert output.contains('intarray')
+	assert output.contains('DATATYPE  H5T_STD_I32LE')
+
+	assert 11 == output.count('DATASET')
+	assert 11 == output.count('DATATYPE')
+	assert 11 == output.count('DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }')
+	assert 11 == output.count('(0): 0, 1')
+	assert 2 == output.count('H5T_STD_I32LE') // i32 and int
+
+	readback()?
+	readback()? // worth doing twice
+}
+
+fn readback() ? {
+	// read_dataset1d will change the mut array size
+	mut i8arrayrd := make1type[i8](1)
+	mut u8arrayrd := make1type[u8](1)
+
+	mut i16arrayrd := make1type[i16](1)
+	mut u16arrayrd := make1type[u16](1)
+
+	mut i32arrayrd := make1type[i32](1)
+	mut u32arrayrd := make1type[u32](1)
+
+	mut i64arrayrd := make1type[i64](1)
+	mut u64arrayrd := make1type[u64](1)
+
+	mut f32arrayrd := make1type[f32](1)
+	mut f64arrayrd := make1type[f64](1)
+
+	mut intarrayrd := make1type[int](1)
+
+	f := hdf5.open_file(testfile.str)?
+
+	f.read_dataset1d(c'i8array', mut i8arrayrd)
+	f.read_dataset1d(c'u8array', mut u8arrayrd)
+	compare1d(i8array, i8arrayrd)
+	compare1d(u8array, u8arrayrd)
+
+	f.read_dataset1d(c'i16array', mut i16arrayrd)
+	f.read_dataset1d(c'u16array', mut u16arrayrd)
+	compare1d(i16array, i16arrayrd)
+	compare1d(u16array, u16arrayrd)
+
+	f.read_dataset1d(c'i32array', mut i32arrayrd)
+	f.read_dataset1d(c'u32array', mut u32arrayrd)
+	compare1d(i32array, i32arrayrd)
+	compare1d(u32array, u32arrayrd)
+
+	f.read_dataset1d(c'i64array', mut i64arrayrd)
+	f.read_dataset1d(c'u64array', mut u64arrayrd)
+	compare1d(i64array, i64arrayrd)
+	compare1d(u64array, u64arrayrd)
+
+	f.read_dataset1d(c'f32array', mut f32arrayrd)
+	f.read_dataset1d(c'f64array', mut f64arrayrd)
+	compare1d(f32array, f32arrayrd)
+	compare1d(f64array, f64arrayrd)
+
+	f.read_dataset1d(c'intarray', mut intarrayrd)
+	compare1d(intarray, intarrayrd)
+
+	f.close()
+}

--- a/hdf5/typeshdf5_test.v
+++ b/hdf5/typeshdf5_test.v
@@ -1,21 +1,11 @@
+module hdf5
+
 import os
-import hdf5
-
-fn make1type[T](a int) []T {
-	return []T{len: a, init: T(it)}
-}
-
-fn compare1d[T](ax []T, bx []T) {
-	assert ax.len == bx.len
-	for i in 0 .. ax.len {
-		assert ax[i] == bx[i]
-	}
-}
 
 const (
 	h5dump     = 'h5dump'
 	h5data     = 'hdf_types.h5'
-	testfolder = os.join_path(os.vtmp_dir(),'vsl','typeshdf5')
+	testfolder = os.join_path(os.vtmp_dir(), 'vsl', 'typeshdf5')
 	testfile   = os.join_path(testfolder, h5data)
 
 	i8array    = make1type[i8](2)
@@ -37,29 +27,29 @@ const (
 )
 
 fn testsuite_begin() {
-	os.rmdir_all(testfolder) or {}
-	os.mkdir_all(testfolder)!
+	os.rmdir_all(hdf5.testfolder) or {}
+	os.mkdir_all(hdf5.testfolder)!
 
-	assert os.exists_in_system_path(h5dump)
+	assert os.exists_in_system_path(hdf5.h5dump)
 
-	f := hdf5.new_file(testfile.str)?
+	f := new_file(hdf5.testfile)?
 
-	f.write_dataset1d(c'i8array', i8array)?
-	f.write_dataset1d(c'u8array', u8array)?
+	f.write_dataset1d('i8array', hdf5.i8array)?
+	f.write_dataset1d('u8array', hdf5.u8array)?
 
-	f.write_dataset1d(c'i16array', i16array)?
-	f.write_dataset1d(c'u16array', u16array)?
+	f.write_dataset1d('i16array', hdf5.i16array)?
+	f.write_dataset1d('u16array', hdf5.u16array)?
 
-	f.write_dataset1d(c'i32array', i32array)?
-	f.write_dataset1d(c'u32array', u32array)?
+	f.write_dataset1d('i32array', hdf5.i32array)?
+	f.write_dataset1d('u32array', hdf5.u32array)?
 
-	f.write_dataset1d(c'i64array', i64array)?
-	f.write_dataset1d(c'u64array', u64array)?
+	f.write_dataset1d('i64array', hdf5.i64array)?
+	f.write_dataset1d('u64array', hdf5.u64array)?
 
-	f.write_dataset1d(c'intarray', intarray)?
+	f.write_dataset1d('intarray', hdf5.intarray)?
 
-	f.write_dataset1d(c'f32array', f32array)?
-	f.write_dataset1d(c'f64array', f64array)?
+	f.write_dataset1d('f32array', hdf5.f32array)?
+	f.write_dataset1d('f64array', hdf5.f64array)?
 
 	f.close()
 }
@@ -70,7 +60,7 @@ fn testsuite_end() {
 
 // verify all datatypes in 1 dimension
 fn test_run() {
-	res := os.execute('h5dump ${testfile}')
+	res := os.execute('h5dump ${hdf5.testfile}')
 	output := res.output.trim_space()
 	assert output.contains('i8array')
 	assert output.contains('u8array')
@@ -103,7 +93,7 @@ fn test_run() {
 	assert 11 == output.count('DATASET')
 	assert 11 == output.count('DATATYPE')
 	assert 11 == output.count('DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }')
-	assert 11 == output.count('(0): 0, 1')
+	assert 11 == output.count('(0): 0, 0') // uninitialized
 	assert 2 == output.count('H5T_STD_I32LE') // i32 and int
 
 	readback()?
@@ -129,35 +119,35 @@ fn readback() ? {
 
 	mut intarrayrd := make1type[int](1)
 
-	f := hdf5.open_file(testfile.str)?
+	f := open_file(hdf5.testfile)?
 
-	f.read_dataset1d(c'i8array', mut i8arrayrd)
-	f.read_dataset1d(c'u8array', mut u8arrayrd)
-	compare1d(i8array, i8arrayrd)
-	compare1d(u8array, u8arrayrd)
+	f.read_dataset1d('i8array', mut i8arrayrd)
+	f.read_dataset1d('u8array', mut u8arrayrd)
+	compare1d(hdf5.i8array, i8arrayrd)
+	compare1d(hdf5.u8array, u8arrayrd)
 
-	f.read_dataset1d(c'i16array', mut i16arrayrd)
-	f.read_dataset1d(c'u16array', mut u16arrayrd)
-	compare1d(i16array, i16arrayrd)
-	compare1d(u16array, u16arrayrd)
+	f.read_dataset1d('i16array', mut i16arrayrd)
+	f.read_dataset1d('u16array', mut u16arrayrd)
+	compare1d(hdf5.i16array, i16arrayrd)
+	compare1d(hdf5.u16array, u16arrayrd)
 
-	f.read_dataset1d(c'i32array', mut i32arrayrd)
-	f.read_dataset1d(c'u32array', mut u32arrayrd)
-	compare1d(i32array, i32arrayrd)
-	compare1d(u32array, u32arrayrd)
+	f.read_dataset1d('i32array', mut i32arrayrd)
+	f.read_dataset1d('u32array', mut u32arrayrd)
+	compare1d(hdf5.i32array, i32arrayrd)
+	compare1d(hdf5.u32array, u32arrayrd)
 
-	f.read_dataset1d(c'i64array', mut i64arrayrd)
-	f.read_dataset1d(c'u64array', mut u64arrayrd)
-	compare1d(i64array, i64arrayrd)
-	compare1d(u64array, u64arrayrd)
+	f.read_dataset1d('i64array', mut i64arrayrd)
+	f.read_dataset1d('u64array', mut u64arrayrd)
+	compare1d(hdf5.i64array, i64arrayrd)
+	compare1d(hdf5.u64array, u64arrayrd)
 
-	f.read_dataset1d(c'f32array', mut f32arrayrd)
-	f.read_dataset1d(c'f64array', mut f64arrayrd)
-	compare1d(f32array, f32arrayrd)
-	compare1d(f64array, f64arrayrd)
+	f.read_dataset1d('f32array', mut f32arrayrd)
+	f.read_dataset1d('f64array', mut f64arrayrd)
+	compare1d(hdf5.f32array, f32arrayrd)
+	compare1d(hdf5.f64array, f64arrayrd)
 
-	f.read_dataset1d(c'intarray', mut intarrayrd)
-	compare1d(intarray, intarrayrd)
+	f.read_dataset1d('intarray', mut intarrayrd)
+	compare1d(hdf5.intarray, intarrayrd)
 
 	f.close()
 }

--- a/hdf5/utils.v
+++ b/hdf5/utils.v
@@ -1,0 +1,41 @@
+module hdf5
+
+// functions for testing
+
+fn compare1d[T](ax []T, bx []T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		assert ax[i] == bx[i]
+	}
+}
+
+fn compare2d[T](ax [][]T, bx [][]T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		compare1d(ax[i], bx[i])
+	}
+}
+
+fn compare3d[T](ax [][][]T, bx [][][]T) {
+	assert ax.len == bx.len
+	for i in 0 .. ax.len {
+		compare2d(ax[i], bx[i])
+	}
+}
+
+fn check2dims[T](ax [][]T, b int, c int) {
+	assert ax.len == b
+	for i in 0 .. ax.len {
+		assert ax[i].len == c
+	}
+}
+
+fn check3dims[T](ax [][][]T, b int, c int, d int) {
+	assert ax.len == b
+	for i in 0 .. ax.len {
+		assert ax[i].len == c
+		for j in 0 .. ax[i].len {
+			assert ax[i][j].len == d
+		}
+	}
+}

--- a/hdf5/v.mod
+++ b/hdf5/v.mod
@@ -1,0 +1,7 @@
+Module {
+        name: 'hdf5'
+        description: 'Hierarchical data storage in a file'
+        version: '0.1.0'
+        license: 'MIT'
+        dependencies: []
+}


### PR DESCRIPTION
Add support for HDF5 library.

HDF5 is a data model, library, and file format for storing and managing data.

This module provides basic support for numeric arrays, scalars and related numeric and string attributes.

See the README and the example.

Website https://hdfgroup.org/solutions/hdf5

Comments and reviews welcome of course.

<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  - run the tests with `./bin/test`

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->
