### PR TITLE
h5: spelling and TODO updates

### DIFF
--- a/fft/fft.c.v
+++ b/fft/fft.c.v
@@ -82,7 +82,7 @@ pub mut:
 	im f64
 }
 
-// create_plan returns a plan to compute a Fourier transform of the given array
+// create_plan returns a plan to compute a Fourier transform of the given array.
 // A plan is reusable for any array of exactly this size and type.
 // The array may be []f32, []f64, or []complx_f32 or []complex_f64.
 pub fn create_plan[T](x T) ?Fftplan {
@@ -100,7 +100,7 @@ pub fn create_plan[T](x T) ?Fftplan {
 	return none
 }
 
-// forward_fft computes a Fourier transform defined by the plan p
+// forward_fft computes a Fourier transform defined by the plan p.
 // The input is []f32 or []f64.
 // The output result (r) is returned in-place, and is complex
 // and real numbers mixed as follows:
@@ -141,7 +141,7 @@ pub fn forward_fft[T](p Fftplan, v T) int {
 	}
 }
 
-// backward_fft computes the backwards Fourier transform defined by the plan r
+// backward_fft computes the backwards Fourier transform defined by the plan r.
 pub fn backward_fft[T](r Fftplan, v T) int {
 	match r {
 		Fft32 {

--- a/io/h5/README.md
+++ b/io/h5/README.md
@@ -34,15 +34,15 @@ import vsl.io.h5
 import math.stats
 import rand
 
-linedata := []f64{len: 21, init: rand.f64()}
+linedata := []f64{len: 21, init: (index*0) + rand.f64()}
 mut meanv := 0.0
 hdffile := 'hdffile.h5'
 
 meanv = stats.mean(linedata)
 
-f := h5.new_file(hdffile)?
-f.write_dataset1d('/randdata', linedata)?
-f.write_attribute('/randdata', 'mean', meanv)?
+f := h5.new_file(hdffile)!
+f.write_dataset1d('/randdata', linedata)!
+f.write_attribute('/randdata', 'mean', meanv)!
 f.close()
 ```
 

--- a/io/h5/README.md
+++ b/io/h5/README.md
@@ -34,7 +34,7 @@ import vsl.io.h5
 import math.stats
 import rand
 
-linedata := []f64{len: 21, init: (index*0) + rand.f64()}
+linedata := []f64{len: 21, init: (0 * it) + rand.f64()}
 mut meanv := 0.0
 hdffile := 'hdffile.h5'
 

--- a/io/h5/TODO.md
+++ b/io/h5/TODO.md
@@ -1,9 +1,7 @@
 # TODO
 
-- [ ] Fixing the error processing arrangement, which is currently a mix of
-option and result types.
 - [ ] Fix the memory consumption for writing 2-d or 3-d arrays: currently this uses
-the flatten() function which is a copy operation.
+the flatten() function which requires a temporary copy of the data.
 - [ ] Add more examples.
 - [ ] Add more datatypes, especially images.
 - [ ] Consider adding a file open-for-update function.

--- a/io/h5/_cflags.c.v
+++ b/io/h5/_cflags.c.v
@@ -3,7 +3,12 @@ module h5
 #flag linux -I/usr/include/hdf5/serial/ -I/usr/local/include
 #flag linux -L/usr/lib -L/usr/lib/x86_64-linux-gnu/hdf5/serial/ -L/usr/local/lib -pthread -lhdf5 -lhdf5_hl
 #flag darwin -I/usr/local/include
-#flag darwin -lhdf5 -lhdf5_hl -L/usr/local/lib
+#flag darwin -L/usr/local/lib
+#flag freebsd -I/usr/local/include
+#flag freebsd -L/usr/local/lib
+#flag openbsd -I/usr/local/include
+#flag openbsd -L/usr/local/lib
+
 #flag -I@VMODROOT
 
 #flag -lhdf5

--- a/io/h5/hdf5_nix.c.v
+++ b/io/h5/hdf5_nix.c.v
@@ -57,9 +57,9 @@ fn C.H5Dclose(dset_id Hdf5HidT) Hdf5HerrT
 fn C.H5Sclose(dset_id Hdf5HidT) Hdf5HerrT
 fn C.H5Fclose(file_id Hdf5HidT) Hdf5HerrT
 
-// hdftype is a Templated function to convert a type to an external const
+// hdftype is a Templated function to convert a type to an external const.
 // It maps the V type name to an HDF5 type name (f64 -> C.H5T_IEEE_F64LE).
-// Not valid for read with Big Endian architectures (SPARC, some POWER machines)
+// Not valid for read on Big Endian architectures (SPARC, some POWER machines).
 fn hdftype[T](x T) Hdf5HidT {
 	$if T is f64 {
 		return C.H5T_IEEE_F64LE
@@ -117,7 +117,7 @@ pub fn (f &Hdf5File) write_dataset1d[T](dset_name string, buffer []T) !Hdf5HerrT
 }
 
 // write_dataset2d writes a 2-d numeric array to a named HDF5 dataset in an HDF5 file.
-// Note: creates a temporary copy of the array.
+// Note: creates and deletes a temporary copy of the array.
 pub fn (f &Hdf5File) write_dataset2d[T](dset_name string, buffer [][]T) !Hdf5HerrT {
 	rank := int(2)
 	dims := [i64(buffer.len), buffer[0].len]
@@ -128,7 +128,7 @@ pub fn (f &Hdf5File) write_dataset2d[T](dset_name string, buffer [][]T) !Hdf5Her
 }
 
 // write_dataset3d writes a numeric 3-d array (layers of 2-d arrays) to a named HDF5 dataset in an HDF5 file.
-// Note: creates a temporary copy of the array.
+// Note: creates and deletes a temporary copy of the array.
 pub fn (f &Hdf5File) write_dataset3d[T](dset_name string, buffer [][][]T) !Hdf5HerrT {
 	rank := int(3)
 	dims := [i64(buffer.len), buffer[0].len, buffer[0][0].len]
@@ -217,7 +217,7 @@ pub fn (f &Hdf5File) write_attribute[T](dset_name string, attr_name string, buff
 	}
 }
 
-// open_file opens an existing HDF5 file
+// open_file opens an existing HDF5 file.
 pub fn open_file(filename string) !Hdf5File {
 	mut f := Hdf5File{
 		filedesc: C.H5Fopen(unsafe { filename.str }, C.H5F_ACC_RDONLY, C.H5P_DEFAULT)


### PR DESCRIPTION
Update the TODO, minor spelling corrections, and re-do the openbsd and freebsd library flags.

The change to the io/h5/README.md file ensures different random numbers not just copies of a single number.

<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  - run the tests with `./bin/test`

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->
