### PR TITLE
examples: fix array.map() using index variable

### DIFF
--- a/examples/ml_linreg_plot/main.v
+++ b/examples/ml_linreg_plot/main.v
@@ -35,7 +35,7 @@ x := data.x.get_col(0)
 y := data.y
 
 lin_space := util.lin_space(0.8, 2.0, 21)
-y_pred := lin_space.map(reg.predict([index]))
+y_pred := lin_space.map(reg.predict([it]))
 
 mut plt := plot.new_plot()
 plt.set_layout(


### PR DESCRIPTION
This PR fix array.map() using index variable.