### PR TITLE
vcl: fix enum fields with duplicate value

### DIFF
--- a/vcl/device.c.v
+++ b/vcl/device.c.v
@@ -5,7 +5,7 @@ pub enum DeviceType as i64 {
 	cpu = (1 << 0)
 	gpu = (1 << 1)
 	accelerator = (1 << 2)
-	default_device = (1 << 0)
+	default_device = (1 << 3)
 	all = 0xFFFFFFFF
 }
 


### PR DESCRIPTION
This PR fix enum fields with duplicate value.

```v
/home/runner/.vmodules/vsl/vcl/device.c.v:8:19: error: enum value `1` already exists
    6 |     gpu = (1 << 1)
    7 |     accelerator = (1 << 2)
    8 |     default_device = (1 << 0)
      |                      ~~~~~~~~
    9 |     all = 0xFFFFFFFF
   10 | }
```