### PR TITLE
Fix indent setting in `.editorconfig` for `*.v` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{v,vsh}]
+[*.{v,vsh,mod}]
 indent_style = tab
 
 [*.rst]

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,8 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 
-# Matches multiple files with brace expansion notation
-[*.v]
-indent_style = space
-indent_size = 8
+[*.{v,vsh}]
+indent_style = tab
 
 [*.rst]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,8 @@
-# top-most EditorConfig file
-root = true
-
-# Unix-style newlines with a newline ending every file
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{v,vsh}]
 indent_style = tab

--- a/fft/v.mod
+++ b/fft/v.mod
@@ -1,8 +1,8 @@
 Module {
-        name: 'fft'
-        description: 'PocketFFT-based Fast Fourier Transform'
-        version: '0.1.0'
-        license: 'MIT'
-	    repo_url: 'https://github.com/vlang/vsl'
-        dependencies: []
+	name: 'fft'
+	description: 'PocketFFT-based Fast Fourier Transform'
+	version: '0.1.0'
+	license: 'MIT'
+	repo_url: 'https://github.com/vlang/vsl'
+	dependencies: []
 }

--- a/inout/h5/v.mod
+++ b/inout/h5/v.mod
@@ -1,7 +1,7 @@
 Module {
-        name: 'h5'
-        description: 'Hierarchical data storage in a file'
-        version: '0.1.0'
-        license: 'MIT'
-        dependencies: []
+	name: 'h5'
+	description: 'Hierarchical data storage in a file'
+	version: '0.1.0'
+	license: 'MIT'
+	dependencies: []
 }

--- a/mpi/v.mod
+++ b/mpi/v.mod
@@ -1,8 +1,8 @@
 Module {
-        name: 'mpi'
-        description: 'Message Passing Interface for parallel computing'
-        version: '0.1.0'
-        license: 'MIT'
-	    repo_url: 'https://github.com/vlang/vsl'
-        dependencies: []
+	name: 'mpi'
+	description: 'Message Passing Interface for parallel computing'
+	version: '0.1.0'
+	license: 'MIT'
+	repo_url: 'https://github.com/vlang/vsl'
+	dependencies: []
 }

--- a/plot/v.mod
+++ b/plot/v.mod
@@ -1,8 +1,8 @@
 Module {
-        name: 'plot'
-        description: 'The VSL Plot lib'
-        version: '0.1.0'
-        license: 'MIT'
-	    repo_url: 'https://github.com/vlang/vsl'
-        dependencies: []
+	name: 'plot'
+	description: 'The VSL Plot lib'
+	version: '0.1.0'
+	license: 'MIT'
+	repo_url: 'https://github.com/vlang/vsl'
+		dependencies: []
 }

--- a/v.mod
+++ b/v.mod
@@ -1,8 +1,8 @@
 Module {
-        name: 'vsl'
-        description: 'The V Scientific Library'
-        version: '0.1.50'
-        license: 'MIT'
-        repo_url: 'https://github.com/vlang/vsl'
-        dependencies: []
+	name: 'vsl'
+	description: 'The V Scientific Library'
+	version: '0.1.50'
+	license: 'MIT'
+	repo_url: 'https://github.com/vlang/vsl'
+	dependencies: []
 }

--- a/vcl/v.mod
+++ b/vcl/v.mod
@@ -1,8 +1,8 @@
 Module {
-        name: 'vcl'
-        description: 'V Computing Language'
-        version: '0.1.0'
-        license: 'MIT'
-	    repo_url: 'https://github.com/vlang/vsl'
-        dependencies: []
+	name: 'vcl'
+	description: 'V Computing Language'
+	version: '0.1.0'
+	license: 'MIT'
+	repo_url: 'https://github.com/vlang/vsl'
+	dependencies: []
 }


### PR DESCRIPTION
Updates a aged setting in the .editorconfig for V files. 

I'm running into some editor interference with the current indent setting. If the current setting would actually be used it would also be incompatible with `v fmt`. 
<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  - run the tests with `./bin/test`

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Style: Updated the code formatting rules. Files with extensions `.v`, `.vsh`, and `.mod` will now use tab-based indentation instead of space-based. This change ensures consistency in code style across these file types.
- Chore: Introduced a new rule to automatically remove trailing whitespace in all files, enhancing the cleanliness and readability of the codebase. 

Please note, these changes are internal and do not affect the functionality or user experience of the software.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->