### PR TITLE
Support default lib paths for m1 macs and MacPorts installations

### DIFF
--- a/fft/_cflags.c.v
+++ b/fft/_cflags.c.v
@@ -2,11 +2,13 @@ module fft
 
 #flag linux -I/usr/local/include
 #flag linux -L/usr/lib -L/usr/local/lib
-#flag darwin -I/usr/local/include
 #flag freebsd -I/usr/local/include
 #flag freebsd -L/usr/local/lib
 #flag openbsd -I/usr/local/include
 #flag openbsd -L/usr/local/lib
+// Intel, M1 brew, and MacPorts
+#flag darwin -I/usr/local/include -I/opt/homebrew/include -L/opt/local/lib
+#flag darwin -L/usr/local/lib -L/opt/homebrew/lib -L/opt/local/lib
 #flag -I@VMODROOT
 
 #flag @VMODROOT/pocket-fft/f32.o

--- a/inout/h5/_cflags.c.v
+++ b/inout/h5/_cflags.c.v
@@ -2,12 +2,13 @@ module h5
 
 #flag linux -I/usr/include/hdf5/serial/ -I/usr/local/include
 #flag linux -L/usr/lib -L/usr/lib/x86_64-linux-gnu/hdf5/serial/ -L/usr/local/lib -pthread
-#flag darwin -I/usr/local/include
-#flag darwin -L/usr/local/lib
 #flag freebsd -I/usr/local/include
 #flag freebsd -L/usr/local/lib
 #flag openbsd -I/usr/local/include
 #flag openbsd -L/usr/local/lib
+// Intel, M1 brew, and MacPorts
+#flag darwin -I/usr/local/include -I/opt/homebrew/include -L/opt/local/lib
+#flag darwin -L/usr/local/lib -L/opt/homebrew/lib -L/opt/local/lib
 #flag -I@VMODROOT
 #flag -lhdf5 -lhdf5_hl
 

--- a/mpi/_cflags.c.v
+++ b/mpi/_cflags.c.v
@@ -2,12 +2,14 @@ module mpi
 
 #flag linux -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/include/x86_64-linux-gnu/mpi -pthread
 #flag linux -pthread -L/usr/lib/x86_64-linux-gnu/openmpi/lib
-#flag darwin -I/usr/local/Cellar/open-mpi/4.1.5/include -I/usr/local/include
-#flag darwin -L/usr/local/opt/libevent/lib -L/usr/local/Cellar/open-mpi/4.1.5/lib -L/usr/local/lib
-#flag freebsd -I/usr/local/Cellar/open-mpi/4.1.5/include -I/usr/local/include
-#flag freebsd -L/usr/local/opt/libevent/lib -L/usr/local/Cellar/open-mpi/4.1.5/lib -L/usr/local/lib
-#flag openbsd -I/usr/local/Cellar/open-mpi/4.1.5/include -I/usr/local/include
-#flag openbsd -L/usr/local/opt/libevent/lib -L/usr/local/Cellar/open-mpi/4.1.5/lib -L/usr/local/lib
+#flag freebsd -I/usr/local/include
+#flag freebsd -L/usr/local/opt/libevent/lib -L/usr/local/lib
+#flag openbsd -I/usr/local/include
+#flag openbsd -L/usr/local/opt/libevent/lib -L/usr/local/lib
+// Intel, M1 brew, and MacPorts
+#flag darwin -I/usr/local/include -I/opt/homebrew/include -I/opt/local/include
+#flag darwin -L/usr/local/lib -L/opt/homebrew/lib -L/opt/local/lib
+#flag darwin -L/usr/local/opt/libevent/lib -L/opt/homebrew/opt/libevent/lib -L/opt/local/opt/libevent/lib
 #flag -I@VMODROOT
 #flag -lmpi
 

--- a/vlas/cflags_d_cblas.v
+++ b/vlas/cflags_d_cblas.v
@@ -4,9 +4,10 @@ module vlas
 #flag linux -L/usr/local/lib -L/usr/lib
 #flag windows -O2
 #flag windows -lgfortran
-#flag darwin -I/usr/local/opt/openblas/include
-#flag darwin -L/usr/local/opt/openblas/lib
-#flag darwin -L/usr/local/opt/lapack/lib
+// Intel, M1 brew, and MacPorts
+#flag darwin -I/usr/local/opt/openblas/include -I/opt/homebrew/opt/openblas/include -I/opt/local/opt/openblas/include
+#flag darwin -L/usr/local/opt/openblas/lib -L/opt/homebrew/opt/openblas/lib -L/opt/local/opt/openblas/lib
+#flag darwin -L/usr/local/opt/lapack/lib -L/opt/homebrew/opt/lapack/lib -L/opt/local/opt/lapack/lib
 #flag -I@VMODROOT
 #flag -lopenblas -llapacke
 

--- a/vlas/cflags_notd_cblas.v
+++ b/vlas/cflags_notd_cblas.v
@@ -4,8 +4,9 @@ module vlas
 #flag linux -L/usr/local/lib -L/usr/lib
 #flag windows -O2
 #flag windows -lgfortran
-#flag darwin -I/usr/local/opt/lapack/include
-#flag darwin -L/usr/local/opt/lapack/lib
+// Intel, M1 brew, and MacPorts
+#flag darwin -I/usr/local/opt/lapack/include -I/opt/homebrew/opt/lapack/include -I/opt/local/opt/lapack/include
+#flag darwin -L/usr/local/opt/lapack/lib -L/opt/homebrew/opt/lapack/lib -L/opt/local/opt/lapack/lib
 #flag -I@VMODROOT
 #flag -llapacke
 


### PR DESCRIPTION
Currently, when trying to run e.g., `examples/mpi_basic_example/main.v` on my m1 mac I'm getting:
```
/Users/t/.vmodules/vsl/mpi/cmpi.h:4:10: fatal error: 'mpi.h' file not found
#include "mpi.h"
         ^~~~~~~
1 error generated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
```

The changes in this PR add support for the default m1 library install paths and allow to compile it. 

As ref., V does this kind of imports e.g. here:
https://github.com/vlang/v/blob/25f54669e25c58a6d6b62e670ec8940ed542f386/vlib/net/openssl/c.v#L19-L27

Alternatively, vdocs have a short mention about the differing paths for macos https://github.com/vlang/v/blob/25f54669e25c58a6d6b62e670ec8940ed542f386/examples/call_v_from_c/README.md#on-mac-osx.


<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  - run the tests with `./bin/test`

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Chore: Enhanced compatibility across different operating systems including Linux, FreeBSD, OpenBSD, and macOS. This update ensures smoother build processes and proper functioning of the software on these platforms.
- New Feature: Added support for Intel, M1 brew, and MacPorts paths. This change improves the software's adaptability and ensures it can be compiled and linked correctly on a wider range of systems.
- Maintenance: Updated the compiler flags to include or exclude certain directories, enhancing the reliability and performance of the software across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->