### PR TITLE
val: update include and lib paths for openmpi

### DIFF
--- a/mpi/_cflags.c.v
+++ b/mpi/_cflags.c.v
@@ -2,8 +2,8 @@ module mpi
 
 #flag linux -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/include/x86_64-linux-gnu/mpi -pthread
 #flag linux -pthread -L/usr/lib/x86_64-linux-gnu/openmpi/lib
-#flag freebsd -I/usr/local/include
-#flag freebsd -L/usr/local/opt/libevent/lib -L/usr/local/lib
+#flag freebsd -I/usr/local/mpi/openmpi/include -I/usr/local/include
+#flag freebsd -L/usr/local/mpi/openmpi/lib  -L/usr/local/opt/libevent/lib -L/usr/local/lib
 #flag openbsd -I/usr/local/include
 #flag openbsd -L/usr/local/opt/libevent/lib -L/usr/local/lib
 // Intel, M1 brew, and MacPorts


### PR DESCRIPTION
On FreeBSD, the `openmpi` package gets installed in `/usr/local/mpi/openmpi` instead of `/usr/local`.  Therefore the include and lib paths need to include `-I/usr/local/mpi/openmpi/include` and `-L/usr/local/mpi/openmpi/lib`.

I notice that if one uses the `mpich` package instead of `openmpi`, the headers and library are in `/usr/local/include` and `/usr/local/lib`.  Then one does not need to make changes to `mpi/_cflags.c.v`. However, with `mpich`, you need to change the types of MPI_Comm and MPI_Group as shown in the following diff.

```
diff --git a/mpi/mpi.c.v b/mpi/mpi.c.v
index b6074401..323096c0 100644
--- a/mpi/mpi.c.v
+++ b/mpi/mpi.c.v
@@ -6,9 +6,9 @@ fn C.MPI_Initialized(flag &int) int
 fn C.MPI_Init(argc int, argv &charptr) int
 fn C.MPI_Init_thread(argc int, argv &charptr, required int, provided &int) int
 
-type MPI_Comm = voidptr
+type MPI_Comm = int
 type MPI_Datatype = voidptr
-type MPI_Group = voidptr
+type MPI_Group = int
 type MPI_Status = voidptr
 type MPI_Op = voidptr
 
@@ -88,7 +88,7 @@ mut:
 pub fn Communicator.new(ranks []int) !&Communicator {
        mut o := &Communicator{
                comm: MPI_Comm(C.MPI_COMM_WORLD)
-               group: unsafe { nil }
+               group: 0
        }
        if ranks.len == 0 {
                C.MPI_Comm_group(C.MPI_COMM_WORLD, &o.group)
```
VSL works with `mpich` after making this patch.
<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  - run the tests with `./bin/test`

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->
