### PR TITLE
poly: fix eval and sorted_3_ + fix tests

### DIFF
--- a/poly/poly.v
+++ b/poly/poly.v
@@ -10,9 +10,11 @@ pub fn eval(c []f64, x f64) f64 {
 		panic('coeficients can not be empty')
 	}
 	len := c.len
-	mut ans := c[len - 1]
-	for e in c[..len - 1] {
-		ans = e + x * ans
+	mut ans := 0.0
+	mut i := len-1
+	for i >= 0{
+		ans = c[i] + x * ans
+		i--
 	}
 	return ans
 }
@@ -131,13 +133,13 @@ fn sorted_3_(x_ f64, y_ f64, z_ f64) (f64, f64, f64) {
 	mut y := y_
 	mut z := z_
 	if x > y {
-		y, x = swap_(x, y)
+		x, y = swap_(x, y)
+	}
+	if x > z {
+		 x, z = swap_(x, z)
 	}
 	if y > z {
-		z, y = swap_(y, z)
-	}
-	if x > y {
-		y, x = swap_(x, y)
+		y, z = swap_(y, z)
 	}
 	return x, y, z
 }

--- a/poly/poly_test.v
+++ b/poly/poly_test.v
@@ -2,11 +2,11 @@ module poly
 
 fn test_eval() {
 	// ans = 2
-	// ans = 4.0 + 4 * 2 = 12
-	// ans = 5 + 4 * 12 = 53
+	// ans = 5 + 4 * 2 = 13
+	// ans = 4 + 4 * 13 = 56
 	x := 4
 	cof := [4.0, 5, 2]
-	assert eval(cof, 4) == 53
+	assert eval(cof, 4) == 56
 }
 
 fn test_swap() {
@@ -16,13 +16,13 @@ fn test_swap() {
 	assert a == 202.0 && b == 101.0
 }
 
-// fn test_sorted_3_(){
-// 	a := 5.0
-// 	b := 7.0
-// 	c := -8.0
-// 	x, y, z := sorted_3_(a, b, c)
-// 	assert y == 7.0
-// }
+fn test_sorted_3_(){
+	a := 5.0
+	b := 7.0
+  c := -8.0
+  x, y, z := sorted_3_(a, b, c)
+  assert y == 5.0
+}
 
 fn test_add() {
 	a := [6.0, 777, -3]
@@ -36,9 +36,10 @@ fn test_substract() {
 	assert substract(a, b) == [5.0, 1532, 1]
 }
 
-// fn test_multiply(){
-// 	a := [9.0, -1, 5]
-// 	b := [0.0, -1, 7]
+fn test_multiply(){
+  a := [9.0, -1, 5]
+	b := [0.0, -1, 7]
 
-// 	assert multiply(a, b) == [0.0, -9, 73, -12, 35, 0]
-// }
+	assert multiply(a, b) == [0.0, -9, 64, -12, 35, 0]
+}
+


### PR DESCRIPTION
This PR fix eval and sorted_3_ function, they returned wrong results.

The new eval function is now faster and return the correct result:
```
C:\Users\loicp\Documents\GitHub\vsl\poly>v run .
time for 10000 old eval: 219.500us
old_eval returned value: 53.0
time for 10000 new eval: 126.700us
new_eval returned value: 56.0
```

I'll add tests for the others functions soon and I can fill some examples to resolve this : #106 