### PR TITLE
Replace panic with vsl_panic in eval function

### DIFF
--- a/poly/poly.v
+++ b/poly/poly.v
@@ -1,13 +1,14 @@
 module poly
 
 import math
+import vsl.errors
 
 const radix = 2
 const radix2 = (radix * radix)
 
 pub fn eval(c []f64, x f64) f64 {
 	if c.len == 0 {
-		panic('coeficients can not be empty')
+		errors.vsl_panic('coeficients can not be empty', .efailed)
 	}
 	len := c.len
 	mut ans := c[len - 1]


### PR DESCRIPTION
### Description:
This pull request updates the eval function to use errors.vsl_panic instead of the standard panic method for error handling. This change ensures that errors are handled in a more consistent manner with other parts of the codebase that use the vsl_panic method for error reporting.

### Changes Made:
Replaced `panic('coeficients can not be empty')` with `errors.vsl_panic('coeficients can not be empty', .efailed)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the evaluation function, enhancing reliability and precision in error reporting.
  
- **New Features**
	- Implemented a more structured error reporting mechanism for better debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->