### PR TITLE
Replace panic with vsl_panic in graph.v

### DIFF
--- a/graph/graph.v
+++ b/graph/graph.v
@@ -92,7 +92,7 @@ pub fn (g &Graph) get_edge(i int, j int) !int {
 */
 pub fn (g &Graph) shortest_paths(method ShortestPaths) Graph {
 	if method != .fw {
-		panic('shortest_paths works with FW (Floyd-Warshall) method only for now')
+		errors.vsl_panic('shortest_paths works with FW (Floyd-Warshall) method only for now', .efailed)
 	}
 	g2 := g.calc_dist()
 	nv := g2.dist.len
@@ -176,7 +176,7 @@ pub fn (g &Graph) calc_dist() Graph {
 		dist[i][j] = d
 		next[i][j] = j
 		if dist[i][j] < 0 {
-			panic('distance between vertices cannot be negative: ${dist}[i][j]')
+			errors.vsl_panic('distance between vertices cannot be negative: ${dist}[i][j]', .efailed)
 		}
 	}
 	return Graph{

--- a/graph/graph.v
+++ b/graph/graph.v
@@ -92,7 +92,8 @@ pub fn (g &Graph) get_edge(i int, j int) !int {
 */
 pub fn (g &Graph) shortest_paths(method ShortestPaths) Graph {
 	if method != .fw {
-		errors.vsl_panic('shortest_paths works with FW (Floyd-Warshall) method only for now', .efailed)
+		errors.vsl_panic('shortest_paths works with FW (Floyd-Warshall) method only for now',
+			.efailed)
 	}
 	g2 := g.calc_dist()
 	nv := g2.dist.len
@@ -176,7 +177,8 @@ pub fn (g &Graph) calc_dist() Graph {
 		dist[i][j] = d
 		next[i][j] = j
 		if dist[i][j] < 0 {
-			errors.vsl_panic('distance between vertices cannot be negative: ${dist}[i][j]', .efailed)
+			errors.vsl_panic('distance between vertices cannot be negative: ${dist}[i][j]',
+				.efailed)
 		}
 	}
 	return Graph{


### PR DESCRIPTION
### Description:
This pull request updates the eval function to use errors.vsl_panic instead of the standard panic method for error handling. This change ensures that errors are handled in a more consistent manner with other parts of the codebase that use the vsl_panic method for error reporting.

### Changes Made:
Replaced:
1. `panic('shortest_paths works with FW (Floyd-Warshall) method only for now')` with `errors.vsl_panic('shortest_paths works with FW (Floyd-Warshall) method only for now', .efailed)`
2. `panic('distance between vertices cannot be negative: ${dist}[i][j]')`with `errors.vsl_panic('distance between vertices cannot be negative: ${dist}[i][j]', .efailed)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Enhanced error handling in the Graph functionality for better consistency and reporting of failures.
  - Updated error responses for unsupported methods and negative distance detection, improving application robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->