### PR TITLE
feat: add polynomial odd-even coefficient sum and degree functions

### DIFF
--- a/poly/README.md
+++ b/poly/README.md
@@ -153,3 +153,44 @@ Divides two polynomials:
 
 Uses polynomial long division algorithm. Returns `(q, r)` where `q` is the quotient and `r`
 is the remainder such that `a(x) = b(x) * q(x) + r(x)` and `degree(r) < degree(b)`.
+
+## Polynomial Degree and Coefficient Sums
+
+```v ignore
+fn degree(c []f64) int
+```
+
+This function returns the degree of the given polynomial.
+The polynomial is represented by the array `c`:
+
+```console
+P(x) = c[0] + c[1] x + c[2] x^2 + ... + c[n] x^n
+```
+
+The function returns the index of the highest non-zero term.
+
+```v ignore
+fn sum_odd_coeffs(c []f64) f64
+```
+
+This function calculates the sum of the coefficients at odd indices
+in the given polynomial. The polynomial is represented by the array `c`:
+
+```console
+P(x) = c[0] + c[1] x + c[2] x^2 + ... + c[n] x^n
+```
+
+The function returns the sum of coefficients `c[1]`, `c[3]`, `c[5]`, etc.
+
+```v ignore
+fn sum_even_coeffs(c []f64) f64
+```
+
+This function calculates the sum of the coefficients at even indices
+in the given polynomial. The polynomial is represented by the array `c`:
+
+```console
+P(x) = c[0] + c[1] x + c[2] x^2 + ... + c[n] x^n
+```
+
+The function returns the sum of coefficients `c[0]`, `c[2]`, `c[4]`, etc.

--- a/poly/poly.v
+++ b/poly/poly.v
@@ -310,3 +310,32 @@ pub fn divide(a []f64, b []f64) ([]f64, []f64) {
 
 	return quotient, remainder
 }
+
+// degree returns the degree of the given polynomial
+// Input: c = [a_0, a_1, ..., a_n]
+// Output: Degree of the polynomial as an integer
+pub fn degree(c []f64) int {
+	return c.len - 1
+}
+
+// sum_odd_coeffs calculates the sum of the coefficients at odd indices
+// Input: c = [a_0, a_1, ..., a_n]
+// Output: Sum of the coefficients at odd indices as a floating-point number
+pub fn sum_odd_coeffs(c []f64) f64 {
+	mut sum := 0.0
+	for i := 1; i < c.len; i += 2 {
+		sum += c[i]
+	}
+	return sum
+}
+
+// sum_even_coeffs calculates the sum of the coefficients at even indices
+// Input: c = [a_0, a_1, ..., a_n]
+// Output: Sum of the coefficients at even indices as a floating-point number
+pub fn sum_even_coeffs(c []f64) f64 {
+	mut sum := 0.0
+	for i := 0; i < c.len; i += 2 {
+		sum += c[i]
+	}
+	return sum
+}

--- a/poly/poly_test.v
+++ b/poly/poly_test.v
@@ -51,5 +51,23 @@ fn test_divide() {
 	println('Divide quotient: ${quotient}')
 	println('Divide remainder: ${remainder}')
 	assert quotient == [1.0, 1.0]
-	assert remainder == [] // The empty set indicates that two polynomials divide each other exactly (without remainder).
+	assert remainder == [] // The empty set indicates that the two polynomials divide each other exactly (without remainder).
+}
+
+fn test_degree() {
+	assert degree([4.0, 5.0, 2.0]) == 2 // Degree should be 2
+	assert degree([1.0]) == 0 // Degree should be 0 for a single coefficient polynomial
+	assert degree([]) == -1 // Degree should be -1 for an empty coefficient array
+}
+
+fn test_sum_odd_coeffs() {
+	assert sum_odd_coeffs([4.0, 5.0, 2.0]) == 5.0 // 5 is at an odd index
+	assert sum_odd_coeffs([7.0, 456.0, 21.0, 87.0]) == 543.0 // 456 and 87 are at odd indices
+	assert sum_odd_coeffs([]) == 0.0 // The sum should be 0 for an empty coefficient array
+}
+
+fn test_sum_even_coeffs() {
+	assert sum_even_coeffs([4.0, 5.0, 2.0]) == 6.0 // 4.0 and 2 are at even indices
+	assert sum_even_coeffs([7.0, 456.0, 21.0, 87.0]) == 28.0 // 7 and 21 are at even indices
+	assert sum_even_coeffs([]) == 0 // The sum should be 0 for an empty coefficient array
 }


### PR DESCRIPTION
This PR introduces three new functions to the `poly` module: `sum_odd_coeffs`, `sum_even_coeffs`, and `degree`. These functions compute specific properties of polynomials based on their coefficients.

1. **sum_odd_coeffs**:
   - Calculates the sum of the coefficients at odd indices.
   - Input: `c = [a_0, a_1, ..., a_n]`
   - Output: Sum of the coefficients at odd indices as a floating-point number.

2. **sum_even_coeffs**:
   - Calculates the sum of the coefficients at even indices.
   - Input: `c = [a_0, a_1, ..., a_n]`
   - Output: Sum of the coefficients at even indices as a floating-point number.

3. **degree**:
   - Returns the degree of the polynomial represented by the coefficient array.
   - Input: `c = [a_0, a_1, ..., a_n]`
   - Output: Degree of the polynomial as an integer.

The corresponding tests have been added to `poly_test.v` to verify the functionality of these new functions.

**Changes:**
- Added the following functions to `poly.v`:
  - `pub fn sum_odd_coeffs(c []f64) f64`
  - `pub fn sum_even_coeffs(c []f64) f64`
  - `pub fn degree(c []f64) int`
- Updated `poly_test.v` to include tests for the new functions.

**Testing:**
- Added unit tests for `sum_odd_coeffs`, `sum_even_coeffs`, and `degree` in `poly_test.v`.
- All tests have been confirmed to pass.