### PR TITLE
la: add vector cosine similarity function and test

### DIFF
--- a/la/vector.v
+++ b/la/vector.v
@@ -1,6 +1,7 @@
 module la
 
 import math
+import vsl.errors
 
 // vector_apply sets this []T with the scaled components of another []T
 // this := a * another   ⇒   this[i] := a * another[i]
@@ -79,4 +80,21 @@ pub fn vector_largest[T](o []T, den T) T {
 		}
 	}
 	return largest / den
+}
+
+// vector_cosine_similarity calculates the cosine similarity between two vectors
+pub fn vector_cosine_similarity(a []f64, b []f64) f64 {
+	if a.len != b.len {
+		errors.vsl_panic('Vectors must have the same length', .efailed)
+	}
+
+	dot_product := vector_dot(a, b)
+	norm_a := vector_norm(a)
+	norm_b := vector_norm(b)
+
+	if norm_a == 0 || norm_b == 0 {
+		return 0
+	}
+
+	return dot_product / (norm_a * norm_b)
 }

--- a/la/vector_test.v
+++ b/la/vector_test.v
@@ -70,3 +70,23 @@ fn test_vector_largest() {
 	l := 2.0
 	assert float64.close(vector_largest(a, 2), l)
 }
+
+fn test_vector_cosine_similarity() {
+	a := [1.0, 2.0, 3.0]
+	b := [4.0, 5.0, 6.0]
+	c := [1.0, 0.0, 0.0]
+	d := [0.0, 1.0, 0.0]
+
+	// Cosine similarity of a and b (should be close to 0.974631846)
+	assert float64.tolerance(vector_cosine_similarity(a, b), 0.974631846, 1e-8)
+
+	// Cosine similarity of a with itself (should be exactly 1)
+	assert float64.close(vector_cosine_similarity(a, a), 1.0)
+
+	// Cosine similarity of perpendicular vectors (should be 0)
+	assert float64.close(vector_cosine_similarity(c, d), 0.0)
+
+	// Cosine similarity of a zero vector with another vector (should be 0)
+	zero_vector := [0.0, 0.0, 0.0]
+	assert float64.close(vector_cosine_similarity(zero_vector, a), 0.0)
+}


### PR DESCRIPTION
This PR adds a new function `vector_cosine_similarity` to calculate the cosine similarity between two vectors, along with corresponding tests.

The new function is documented and implemented as follows:
```v
// vector_cosine_similarity calculates the cosine similarity between two vectors
pub fn vector_cosine_similarity(a []f64, b []f64) f64 {
    if a.len != b.len {
        errors.vsl_panic('Vectors must have the same length', .efailed)
    }

    dot_product := vector_dot(a, b)
    norm_a := vector_norm(a)
    norm_b := vector_norm(b)

    if norm_a == 0 || norm_b == 0 {
        return 0
    }

    return dot_product / (norm_a * norm_b)
}
```

Tests have been added to verify the correctness of the new function:

```v
fn test_vector_cosine_similarity() {
    a := [1.0, 2.0, 3.0]
    b := [4.0, 5.0, 6.0]
    c := [1.0, 0.0, 0.0]
    d := [0.0, 1.0, 0.0]

    // Cosine similarity of a and b (should be close to 0.974631846)
    assert float64.tolerance(vector_cosine_similarity(a, b), 0.974631846, 1e-8)

    // Cosine similarity of a with itself (should be exactly 1)
    assert float64.close(vector_cosine_similarity(a, a), 1.0)

    // Cosine similarity of perpendicular vectors (should be 0)
    assert float64.close(vector_cosine_similarity(c, d), 0.0)

    // Cosine similarity of a zero vector with another vector (should be 0)
    zero_vector := [0.0, 0.0, 0.0]
    assert float64.close(vector_cosine_similarity(zero_vector, a), 0.0)
}
```

This new function enhances the vector operations capabilities of the `la` module by providing a way to measure the similarity between two vectors, which is useful in various applications such as text analysis, recommendation systems, and machine learning.