### PR TITLE
fix(iter): make combinations and permutations generic

### DIFF
--- a/iter/comb.v
+++ b/iter/comb.v
@@ -4,40 +4,38 @@ import vsl.fun
 import vsl.util
 
 // combinations will return an array of all length `r` combinations of `data`
-// While waiting on https://github.com/vlang/v/issues/7753 to be fixed, the function
-// assumes f64 array input. Will be easy to change to generic later
-pub fn combinations(data []f64, r int) [][]f64 {
+pub fn combinations[T](data []T, r int) [][]T {
 	mut combinations := CombinationsIter.new(data, r)
-	mut result := [][]f64{cap: int(combinations.size)}
+	mut result := [][]T{cap: int(combinations.size)}
 	for comb in combinations {
 		result << comb
 	}
 	return result
 }
 
-pub struct CombinationsIter {
+pub struct CombinationsIter[T] {
 mut:
 	pos  u64
 	idxs []int
 pub:
 	repeat int
 	size   u64
-	data   []f64
+	data   []T
 }
 
 // CombinationsIter.new will return an iterator that allows
 // lazy computation for all length `r` combinations of `data`
-pub fn CombinationsIter.new(data []f64, r int) CombinationsIter {
+pub fn CombinationsIter.new[T](data []T, r int) CombinationsIter[T] {
 	n := data.len
 	if r > n {
-		return CombinationsIter{
+		return CombinationsIter[T]{
 			data:   data
 			repeat: r
 		}
 	}
 	size := u64(fun.choose(n, r))
 	idxs := util.arange(r)
-	return CombinationsIter{
+	return CombinationsIter[T]{
 		data:   data
 		repeat: r
 		size:   size
@@ -46,7 +44,7 @@ pub fn CombinationsIter.new(data []f64, r int) CombinationsIter {
 }
 
 // next will return next combination if possible
-pub fn (mut o CombinationsIter) next() ?[]f64 {
+pub fn (mut o CombinationsIter[T]) next() ?[]T {
 	// base case for every iterator
 	if o.pos == o.size {
 		return none
@@ -82,39 +80,38 @@ pub fn (mut o CombinationsIter) next() ?[]f64 {
 // This is as close a translation of python's [itertools.combinations_with_replacement]
 // (https://docs.python.org/3.9/library/itertools.html#itertools.combinations_with_replacement)
 // as I could manage.
-// Using f64 array instead of generic while waiting on https://github.com/vlang/v/issues/7753
-pub fn combinations_with_replacement(data []f64, r int) [][]f64 {
+pub fn combinations_with_replacement[T](data []T, r int) [][]T {
 	mut combinations := CombinationsWithReplacementIter.new(data, r)
-	mut result := [][]f64{cap: int(combinations.size)}
+	mut result := [][]T{cap: int(combinations.size)}
 	for comb in combinations {
 		result << comb
 	}
 	return result
 }
 
-pub struct CombinationsWithReplacementIter {
+pub struct CombinationsWithReplacementIter[T] {
 mut:
 	pos  u64
 	idxs []int
 pub:
 	repeat int
 	size   u64
-	data   []f64
+	data   []T
 }
 
 // CombinationsWithReplacementIter.new will return an iterator that allows
 // lazy computation for all length `r` combinations with replacement of `data`
-pub fn CombinationsWithReplacementIter.new(data []f64, r int) CombinationsWithReplacementIter {
+pub fn CombinationsWithReplacementIter.new[T](data []T, r int) CombinationsWithReplacementIter[T] {
 	n := data.len
 	if r > n {
-		return CombinationsWithReplacementIter{
+		return CombinationsWithReplacementIter[T]{
 			data:   data
 			repeat: r
 		}
 	}
 	size := fun.n_combos_w_replacement(n, r)
 	idxs := []int{len: r, init: 0}
-	return CombinationsWithReplacementIter{
+	return CombinationsWithReplacementIter[T]{
 		data:   data
 		repeat: r
 		size:   size
@@ -123,7 +120,7 @@ pub fn CombinationsWithReplacementIter.new(data []f64, r int) CombinationsWithRe
 }
 
 // next will return next combination if possible
-pub fn (mut o CombinationsWithReplacementIter) next() ?[]f64 {
+pub fn (mut o CombinationsWithReplacementIter[T]) next[T]() ?[]T {
 	// base case for every iterator
 	if o.pos == o.size {
 		return none

--- a/iter/comb_test.v
+++ b/iter/comb_test.v
@@ -44,6 +44,20 @@ fn test_combinations_longer() {
 	assert expected == result
 }
 
+fn test_combinations_with_genric_type_string() {
+	data := ['a', 'b', 'c']
+	expected := [['a', 'b'], ['a', 'c'], ['b', 'c']]
+	result := combinations(data, 2)
+	assert expected == result
+}
+
+fn test_combinations_with_genric_type_int() {
+	data := [1, 2, 3]
+	expected := [[1, 2], [1, 3], [2, 3]]
+	result := combinations(data, 2)
+	assert expected == result
+}
+
 fn test_combinations_with_replacement_choose_1() {
 	data := [1.0, 2.0, 3.0]
 	expected := [[1.0], [2.0], [3.0]]

--- a/iter/comb_test.v
+++ b/iter/comb_test.v
@@ -44,14 +44,14 @@ fn test_combinations_longer() {
 	assert expected == result
 }
 
-fn test_combinations_with_genric_type_string() {
+fn test_combinations_with_generic_type_string() {
 	data := ['a', 'b', 'c']
 	expected := [['a', 'b'], ['a', 'c'], ['b', 'c']]
 	result := combinations(data, 2)
 	assert expected == result
 }
 
-fn test_combinations_with_genric_type_int() {
+fn test_combinations_with_generic_type_int() {
 	data := [1, 2, 3]
 	expected := [[1, 2], [1, 3], [2, 3]]
 	result := combinations(data, 2)

--- a/iter/perm.v
+++ b/iter/perm.v
@@ -3,7 +3,7 @@ module iter
 import vsl.util
 import math
 
-pub struct PermutationsIter {
+pub struct PermutationsIter[T] {
 mut:
 	pos    u64
 	idxs   []int
@@ -11,15 +11,15 @@ mut:
 pub:
 	repeat int
 	size   u64
-	data   []f64
+	data   []T
 }
 
 // PermutationsIter.new will return an iterator that allows
 // lazy computation for all length `r` permutations of `data`
-pub fn PermutationsIter.new(data []f64, r int) PermutationsIter {
+pub fn PermutationsIter.new[T](data []T, r int) PermutationsIter[T] {
 	n := data.len
 	if r > n {
-		return PermutationsIter{
+		return PermutationsIter[T]{
 			data:   data
 			repeat: r
 		}
@@ -27,7 +27,7 @@ pub fn PermutationsIter.new(data []f64, r int) PermutationsIter {
 	size := u64(math.factorial(n) / math.factorial(n - r))
 	idxs := util.arange(n)
 	cycles := util.range(n, n - r, step: -1)
-	return PermutationsIter{
+	return PermutationsIter[T]{
 		data:   data
 		repeat: r
 		size:   size
@@ -37,7 +37,7 @@ pub fn PermutationsIter.new(data []f64, r int) PermutationsIter {
 }
 
 // next will return next permutation if possible
-pub fn (mut o PermutationsIter) next() ?[]f64 {
+pub fn (mut o PermutationsIter[T]) next[T]() ?[]T {
 	// base case for every iterator
 	if o.pos == o.size {
 		return none
@@ -69,9 +69,9 @@ pub fn (mut o PermutationsIter) next() ?[]f64 {
 }
 
 // permutations returns successive `r` length permutations of elements in `data`
-pub fn permutations(data []f64, r int) [][]f64 {
-	mut perms := PermutationsIter.new(data, r)
-	mut result := [][]f64{cap: int(perms.size)}
+pub fn permutations[T](data []T, r int) [][]T {
+	mut perms := PermutationsIter.new[T](data, r)
+	mut result := [][]T{cap: int(perms.size)}
 	for perm in perms {
 		result << perm
 	}

--- a/iter/perm_test.v
+++ b/iter/perm_test.v
@@ -64,7 +64,22 @@ fn test_permutations_simple_5() {
 	assert assert_permutation(expected, result)
 }
 
-fn assert_permutation(a [][]f64, b [][]f64) bool {
+fn test_permutations_generic_type_string() {
+	data := ['a', 'b', 'c']
+	expected := [['a', 'b'], ['a', 'c'], ['b', 'a'], ['b', 'c'],
+		['c', 'a'], ['c', 'b']]
+	result := permutations(data, 2)
+	assert assert_permutation(expected, result)
+}
+
+fn test_permutations_generic_type_int() {
+	data := [1, 2, 3]
+	expected := [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
+	result := permutations(data, 2)
+	assert assert_permutation(expected, result)
+}
+
+fn assert_permutation[T](a [][]T, b [][]T) bool {
 	if a.len != b.len {
 		return false
 	}


### PR DESCRIPTION
This PR makes iter functions like combinations and permutations generic.

I also added test cases for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for generic types in combination and permutation functions, allowing operations on arrays of any type.
	- Enhanced combination and permutation iterators to handle various data types.

- **Bug Fixes**
	- Improved test coverage for combination and permutation functionalities with new test cases for string and integer types.

- **Tests**
	- Added tests for combinations and permutations with generic types.
	- Updated assertion functions to support generic comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->