### PR TITLE
DeviceType:  Fix values to match cl.h values

### DIFF
--- a/vcl/device.c.v
+++ b/vcl/device.c.v
@@ -2,9 +2,11 @@ module vcl
 
 pub enum DeviceType as i64 {
 	// device types - bitfield
-	cpu         = (1 << 0)
-	gpu         = (1 << 1)
-	accelerator = (1 << 2)
+	default     = (1 << 0)
+	cpu         = (1 << 1)
+	gpu         = (1 << 2)
+	accelerator = (1 << 3)
+	custom      = (1 << 4)
 	all         = 0xFFFFFFFF
 }
 


### PR DESCRIPTION
Hi

The values for the DeviceType in vsl/vcl/device.c.v does not seem to match the cl.h values which are  :
```
/* cl_device_type - bitfield */
#define CL_DEVICE_TYPE_DEFAULT                      (1 << 0)
#define CL_DEVICE_TYPE_CPU                          (1 << 1)
#define CL_DEVICE_TYPE_GPU                          (1 << 2)
#define CL_DEVICE_TYPE_ACCELERATOR                  (1 << 3)
#ifdef CL_VERSION_1_2
#define CL_DEVICE_TYPE_CUSTOM                       (1 << 4)
#endif
#define CL_DEVICE_TYPE_ALL                          0xFFFFFFFF
```

In my opinion you should have in device.c.v
```
pub enum DeviceType as i64 {
    // device types - bitfield
    default     = (1 << 0)
    cpu         = (1 << 1)
    gpu         = (1 << 2)
    accelerator = (1 << 3)
    custom      = (1 << 4)
    all         = 0xFFFFFFFF
}
```

Currently when you think you selected the gpu you are in fact using the cpu...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new device types: "default" and "custom" for device selection.

* **Refactor**
  * Updated device type assignments to new bit positions for improved clarity in device selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->